### PR TITLE
Make ngraph shape and dtype private members of ngraph::Compiler

### DIFF
--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -506,11 +506,8 @@ void GraphExecutor::Init(nnvm::Symbol symbol,
   g = infer_graph(g);
 
 #if MXNET_USE_NGRAPH == 1
-  std::unordered_map<std::string, TShape> ngraph_arg_shape_map;
-  std::unordered_map<std::string, int> ngraph_arg_dtype_map;
-
-  ngraph::Compiler compiler(g);
-  g = compiler.Compile(ngraph_arg_shape_map, ngraph_arg_dtype_map, feed_dict);
+  ngraph::Compiler compiler(g, feed_dict);
+  g = compiler.Compile();
   
   g = InitFullGraph(g, symbol.ListInputs(nnvm::Symbol::kReadOnlyArgs), 
     grad_req_types);
@@ -869,11 +866,8 @@ void GraphExecutor::Init(nnvm::Symbol symbol,
 
 
 #if MXNET_USE_NGRAPH == 1
-  std::unordered_map<std::string, TShape> ngraph_arg_shape_map;
-  std::unordered_map<std::string, int> ngraph_arg_dtype_map;
-
-  ngraph::Compiler compiler(g);
-  g = compiler.Compile(ngraph_arg_shape_map, ngraph_arg_dtype_map, feed_dict);
+  ngraph::Compiler compiler(g, feed_dict);
+  g = compiler.Compile();
   // create "device" and "context" attrs for the graph
   g = InitFullGraph(g, symbol.ListInputs(nnvm::Symbol::kReadOnlyArgs), grad_req_types);
 
@@ -894,7 +888,7 @@ void GraphExecutor::Init(nnvm::Symbol symbol,
 
   // auto ng_g = compiler.ParseNNVMGraph(g);
   // ng_g.WriteSubgraphDots("out");
-  g = infer_graph(g, ngraph_arg_shape_map, ngraph_arg_dtype_map);
+  g = infer_graph(g, compiler.GetNgraphShape(), compiler.GetNgraphDtype());
   
 #else
   const auto& idx = g.indexed_graph();

--- a/src/ngraph/ngraph_compiler.cc
+++ b/src/ngraph/ngraph_compiler.cc
@@ -41,17 +41,12 @@ layerGraphs create_layerGraphs() {
 }
 
 // Compiler initialization
-Compiler::Compiler(const nnvm::Graph& graph) : graph_(graph) {
+Compiler::Compiler(const nnvm::Graph& graph,
+                   const nnvm::NodeEntryMap<mxnet::NDArray>& feed_dict)
+    : graph_(graph) {
   // initialize ngraph_
   ParseNNVMGraph();
   CheckInNGraph();
-}
-
-// Main compilation function
-nnvm::Graph Compiler::Compile(
-    std::unordered_map<std::string, nnvm::TShape>& arg_shape_map,
-    std::unordered_map<std::string, int>& arg_dtype_map,
-    const nnvm::NodeEntryMap<mxnet::NDArray>& feed_dict) {
   ngraph_.IdentifySubgraphs([&feed_dict](NodePtr s) {
     bool in_feed_dict = false;
     for (auto kv : feed_dict) {
@@ -62,13 +57,18 @@ nnvm::Graph Compiler::Compile(
     }
     return (s->in_ngraph && s->type == NodeType::kOp && !in_feed_dict);
   });
+}
 
+// Main compilation function
+nnvm::Graph Compiler::Compile() {
+  // Output Graphviz dot files (pre collapse) for vizualization
   if (false) ngraph_.WriteSubgraphDots("pre_collapse");
+
   ngraph_.CollapseSubgraphs();
 
-  // Output Graphviz dot files for vizualization
+  // Output Graphviz dot files (post collapse) for vizualization
   if (false) ngraph_.WriteSubgraphDots("post_collapse");
-  // throw;
+
   for (auto node : ngraph_.nodes_) {
     // store the input variable shape for use by nnvm
     // This is happening because my nnvm graph manipulations are
@@ -76,8 +76,8 @@ nnvm::Graph Compiler::Compile(
     // don't get properly inferred. Works, because we're inferring
     // the shapes before doing all of this, but not ideal
     if (node->type != NodeType::kGraph) {
-      arg_shape_map[node->name] = node->shape;
-      arg_dtype_map[node->name] = node->dtype;
+      ngraphShape_[node->name] = node->shape;
+      ngraphDtype_[node->name] = node->dtype;
     }
   }
 

--- a/src/ngraph/ngraph_compiler.h
+++ b/src/ngraph/ngraph_compiler.h
@@ -9,19 +9,22 @@ namespace ngraph {
 // map aliases for maps of name, function, where function returns an ngraph
 // pyobject
 using layerGraphs = std::map<std::string, std::function<Graph(const NodePtr)>>;
+using ngraphShape = std::unordered_map<std::string, nnvm::TShape>;
+using ngraphDtype = std::unordered_map<std::string, int>;
 
 class Compiler {
  public:
-  Compiler(const nnvm::Graph& graph);
+  Compiler(const nnvm::Graph& graph,
+           const nnvm::NodeEntryMap<mxnet::NDArray>& feed_dict);
   // Main interface from MXNet
   // Compile a graph, take an MXNet graph and replace subsections of it
   // with ngraph operations
-  nnvm::Graph Compile(
-      std::unordered_map<std::string, nnvm::TShape>& arg_shape_map,
-      std::unordered_map<std::string, int>& arg_dtype_map,
-      const nnvm::NodeEntryMap<mxnet::NDArray>& feed_dict);
+  nnvm::Graph Compile();
   // parse the nnvm graph into an intermediate rep
   void ParseNNVMGraph();
+
+  const ngraphShape& GetNgraphShape() { return ngraphShape_; }
+  const ngraphDtype& GetNgraphDtype() { return ngraphDtype_; }
 
  private:
   // check nodes against ngraph operations
@@ -30,6 +33,8 @@ class Compiler {
   PyCompiler compiler_;
   nnvm::Graph graph_;
   ngraph::Graph ngraph_;
+  ngraphShape ngraphShape_;
+  ngraphDtype ngraphDtype_;
 };
 
 }  // end namespace ngraph


### PR DESCRIPTION
Also, move feed_dict and subgraph identification to ctor.