### PR TITLE
NGMX-113 implement cast in the emitter

### DIFF
--- a/src/ngraph/ngraph_compiler.h
+++ b/src/ngraph/ngraph_compiler.h
@@ -112,6 +112,8 @@ static std::unordered_map<std::string, std::string> nameswitch({
     // Layer Ops
     {"Concat", "concat"},
     {"Flatten", "flatten"},
+    // Unary
+    {"Cast", "cast"},
 });
 
 // Utility function for replacing operation names

--- a/src/ngraph/ngraph_emitter.cc
+++ b/src/ngraph/ngraph_emitter.cc
@@ -182,6 +182,10 @@ void Emitter::CreateUnaryOps() {
   // ngraph_op_funcs_["gammaln"] = [this](const NodePtr& node){
   //   return ;
   // };
+  ngraph_op_funcs_["cast"] = [this](const NodePtr& node) {
+    return std::make_shared<ngraph::op::Convert>(op_map_[node->inputs_[0]],
+                                                 getType(node->dtype_));
+  };
 }
 
 // autobroadcast factory function to avoid code copy

--- a/src/ngraph/ngraph_graph.cc
+++ b/src/ngraph/ngraph_graph.cc
@@ -195,12 +195,10 @@ std::vector<NodePtr> FindSubgraph(Graph &graph, NodePtr node,
   auto subgraph_nodes = SelectNodes(node, func);
   std::vector<NodePtr> outNodes;
   outNodes = subgraph_nodes;
-  if (subgraph_nodes.size() > 2) {
-    // search for broken loops
-    // remove nodes on broken loops
-    outNodes = RemoveBroken(node, outNodes, func);
-    outNodes = PruneSubgraphOutputs(graph, node, outNodes, func);
-  }
+  // search for broken loops
+  // remove nodes on broken loops
+  outNodes = RemoveBroken(node, outNodes, func);
+  outNodes = PruneSubgraphOutputs(graph, node, outNodes, func);
   return outNodes;
 }
 
@@ -213,13 +211,11 @@ void IdentifySubgraphs(Graph &graph, std::function<bool(NodePtr)> func) {
       // select nodes in the a subgraph starting here and going up the graph
       auto subgraph_nodes = FindSubgraph(graph, i, func);
       // if we found a significantly large subgraph, label it
-      if (subgraph_nodes.size() > 2) {
-        for (auto node : subgraph_nodes) node->subgraph_ = sg;
-        for (auto node : subgraph_nodes)
-          for (auto i : node->inputs_)
-            if (i->subgraph_ != sg) i->subgraph_ = -1;
-        sg += 1;
-      }
+      for (auto node : subgraph_nodes) node->subgraph_ = sg;
+      for (auto node : subgraph_nodes)
+        for (auto i : node->inputs_)
+          if (i->subgraph_ != sg) i->subgraph_ = -1;
+      sg += 1;
     }
   }
 }


### PR DESCRIPTION
## Description ##
implement cast in the emitter
remove restriction that graph must be >2 nodes for ease of testing
NOTE:  I am purposefully NOT creating emitter unit tests for this change because they are of dubious value.  I did hand-write a python unit test (forward pass only) for cast and saw that this change is working.  I tried running 'test_cast' in test_operator.py and hit changes with bprop which I forwarded onto the ngraph team.

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated.
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

