### PR TITLE
adding back random string for subgraph name

### DIFF
--- a/src/ngraph/ngraph_graph.cc
+++ b/src/ngraph/ngraph_graph.cc
@@ -226,7 +226,7 @@ void CollapseSubgraphs(Graph &graph) {
   // loop variable for undefined number of subgraphs
   int i = 1;
   while (true) {
-    auto tmpGraph = std::make_shared<Graph>("subgraph_" + std::to_string(i));
+    auto tmpGraph = std::make_shared<Graph>("subgraph_" + randomString(12) + std::to_string(i));
     // loop over all nodes and add nodes in the current subgraph to
     for (auto node : graph.nodes_)
       if (node->subgraph_ == i) tmpGraph->AddNode(node);


### PR DESCRIPTION
accidentally dropped during ngraph_bridge::Node const refactor
needed in order to support python unittests