### PR TITLE
NGMX-179 Resolved the issue of multiple backend/manager instances

### DIFF
--- a/include/mxnet/base.h
+++ b/include/mxnet/base.h
@@ -26,13 +26,13 @@
 
 #include <dmlc/base.h>
 #include <dmlc/io.h>
-#include <dmlc/type_traits.h>
 #include <dmlc/parameter.h>
+#include <dmlc/type_traits.h>
 #include <mshadow/tensor.h>
 // nnvm headers for symbolic construction.
 #include <nnvm/op.h>
-#include <nnvm/tuple.h>
 #include <nnvm/symbolic.h>
+#include <nnvm/tuple.h>
 #include <string>
 
 /*!
@@ -64,7 +64,7 @@
 #endif
 
 /*! \brief Error message for using gpu when MXNET_USE_CUDA==0 */
-#define MXNET_GPU_NOT_ENABLED_ERROR  "GPU is not enabled"
+#define MXNET_GPU_NOT_ENABLED_ERROR "GPU is not enabled"
 
 /*!
  * \brief define compatible keywords in g++
@@ -102,9 +102,9 @@
  * \brief define operator message for profiler
  */
 #if MXNET_USE_PROFILER
-#define PROFILER_MESSAGE(msg)     msg
+#define PROFILER_MESSAGE(msg) msg
 #else
-#define PROFILER_MESSAGE(msg)     nullptr
+#define PROFILER_MESSAGE(msg) nullptr
 #endif
 
 /*! \brief major version */
@@ -114,9 +114,10 @@
 /*! \brief patch version */
 #define MXNET_PATCH 0
 /*! \brief mxnet version */
-#define MXNET_VERSION (MXNET_MAJOR*10000 + MXNET_MINOR*100 + MXNET_PATCH)
+#define MXNET_VERSION (MXNET_MAJOR * 10000 + MXNET_MINOR * 100 + MXNET_PATCH)
 /*! \brief helper for making version number */
-#define MXNET_MAKE_VERSION(major, minor, patch) ((major)*10000 + (minor)*100 + patch)
+#define MXNET_MAKE_VERSION(major, minor, patch)                                \
+  ((major)*10000 + (minor)*100 + patch)
 /*!
  * \brief define function name as profiler message
  */
@@ -157,7 +158,8 @@ struct Context {
    * \return cpu::kDevMask or gpu::kDevMask
    */
   inline int dev_mask() const {
-    if (dev_type == kCPUPinned || dev_type == kNNP) return cpu::kDevMask;
+    if (dev_type == kCPUPinned || dev_type == kNNP)
+      return cpu::kDevMask;
     return dev_type;
   }
   /*!
@@ -179,9 +181,7 @@ struct Context {
    * \param b another context to compare
    * \return whether they are not the same
    */
-  inline bool operator!=(const Context &b) const {
-    return !(*this == b);
-  }
+  inline bool operator!=(const Context &b) const { return !(*this == b); }
   /*!
    * \brief save the content into binary stream
    * \param strm the output stream
@@ -196,8 +196,10 @@ struct Context {
    * \return whether the load is successful
    */
   inline bool Load(dmlc::Stream *strm) {
-    if (strm->Read(&dev_type, sizeof(dev_type)) != sizeof(dev_type)) return false;
-    if (strm->Read(&dev_id, sizeof(int32_t)) != sizeof(int32_t)) return false;
+    if (strm->Read(&dev_type, sizeof(dev_type)) != sizeof(dev_type))
+      return false;
+    if (strm->Read(&dev_id, sizeof(int32_t)) != sizeof(int32_t))
+      return false;
     return true;
   }
   /*! \brief the maximal device type */
@@ -227,7 +229,7 @@ struct Context {
   /*!
    * Create a NNP context.
    * \param dev_id the device id for corresponding NNP.
-   * \return NNP context. 
+   * \return NNP context.
    */
   inline static Context NNP(int32_t dev_id = 0);
 
@@ -255,16 +257,13 @@ struct RunContext {
    * \return the mshadow stream
    * \tparam xpu the device type of the stream
    */
-  template<typename xpu>
-  inline mshadow::Stream<xpu>* get_stream() const {
-    return static_cast<mshadow::Stream<xpu>*>(stream);
+  template <typename xpu> inline mshadow::Stream<xpu> *get_stream() const {
+    return static_cast<mshadow::Stream<xpu> *>(stream);
   }
   /*! \brief get the base Context from RunContext */
-  inline const Context& get_ctx() const {
-    return ctx;
-  }
+  inline const Context &get_ctx() const { return ctx; }
 };
-}  // namespace mxnet
+} // namespace mxnet
 
 //! \cond Doxygen_Suppress
 namespace mxnet {
@@ -293,31 +292,25 @@ inline Context Context::Create(DeviceType dev_type, int32_t dev_id) {
   }
   return ctx;
 }
-inline Context Context::CPU(int32_t dev_id) {
-  return Create(kCPU, dev_id);
-}
+inline Context Context::CPU(int32_t dev_id) { return Create(kCPU, dev_id); }
 
 inline Context Context::CPUPinned(int32_t dev_id) {
   return Create(kCPUPinned, dev_id);
 }
 
-inline Context Context::GPU(int32_t dev_id) {
-  return Create(kGPU, dev_id);
-}
+inline Context Context::GPU(int32_t dev_id) { return Create(kGPU, dev_id); }
 
-inline Context Context::NNP(int32_t dev_id) {
-  return Create(kNNP, dev_id);
-}
+inline Context Context::NNP(int32_t dev_id) { return Create(kNNP, dev_id); }
 inline Context Context::FromString(std::string str) {
   Context ret;
   try {
     std::string::size_type l = str.find('(');
     CHECK_NE(l, std::string::npos);
     std::string::size_type r = str.find(')');
-    CHECK_EQ(r, str.length()-1);
+    CHECK_EQ(r, str.length() - 1);
 
     std::string type = str.substr(0, l);
-    int id = std::stoi(str.substr(l+1, r-l-1));
+    int id = std::stoi(str.substr(l + 1, r - l - 1));
     if (type == "cpu") {
       ret = CPU(id);
     } else if (type == "gpu") {
@@ -335,7 +328,7 @@ inline Context Context::FromString(std::string str) {
   return ret;
 }
 
-inline std::ostream& operator<<(std::ostream &out, const Context &ctx) {
+inline std::ostream &operator<<(std::ostream &out, const Context &ctx) {
   if (ctx.dev_type == Context::kCPU) {
     out << "cpu(";
   } else if (ctx.dev_type == Context::kGPU) {
@@ -354,11 +347,12 @@ inline std::ostream& operator<<(std::ostream &out, const Context &ctx) {
 // describe op registration point
 #define STRINGIZE_DETAIL(x) #x
 #define STRINGIZE(x) STRINGIZE_DETAIL(x)
-#define MXNET_DESCRIBE(...) describe(__VA_ARGS__ "\n\nFrom:" __FILE__ ":" STRINGIZE(__LINE__))
+#define MXNET_DESCRIBE(...)                                                    \
+  describe(__VA_ARGS__ "\n\nFrom:" __FILE__ ":" STRINGIZE(__LINE__))
 #define ADD_FILELINE "\n\nDefined in " __FILE__ ":L" STRINGIZE(__LINE__)
 
-}  // namespace mxnet
+} // namespace mxnet
 
 #include "./tensor_blob.h"
 //! \endcond
-#endif  // MXNET_BASE_H_
+#endif // MXNET_BASE_H_

--- a/src/ngraph/.clang-format
+++ b/src/ngraph/.clang-format
@@ -1,1 +1,3 @@
-{ BasedOnStyle: "Google", IndentWidth: 2, BreakBeforeBraces: Attach }
+BasedOnStyle: "Google"
+IndentWidth : 2
+BreakBeforeBraces : Attach

--- a/src/ngraph/ngraph_graph.h
+++ b/src/ngraph/ngraph_graph.h
@@ -47,12 +47,12 @@ enum class NodeType { kVariable, kAux, kOp, kGraph };
 // Base class for Nodes in Intermediary Analysis Graph
 class Node {
  protected:
-  Node(NodeType type, nnvmNodePtr node, const std::string& name)
+  Node(NodeType type, nnvmNodePtr node, const std::string &name)
       : type_(type),
         orig_node_(node),
         name_(name == "" ? randomString(6) : name) {}
-  Node(NodeType type, nnvmNodePtr node, const std::string& name,
-       const std::vector<NodePtr>& inputs)
+  Node(NodeType type, nnvmNodePtr node, const std::string &name,
+       const std::vector<NodePtr> &inputs)
       : type_(type),
         orig_node_(node),
         name_(name == "" ? randomString(6) : name),
@@ -88,10 +88,10 @@ class Node {
 class VariableNode : public Node {
  public:
   // Overloaded constructors for ease of use
-  VariableNode(nnvmNodePtr node, const std::string& name)
+  VariableNode(nnvmNodePtr node, const std::string &name)
       : Node(NodeType::kVariable, node, name) {}
-  VariableNode(nnvmNodePtr node, const std::string& name,
-               const std::vector<NodePtr>& inputs)
+  VariableNode(nnvmNodePtr node, const std::string &name,
+               const std::vector<NodePtr> &inputs)
       : Node(NodeType::kVariable, node, name, inputs) {}
 };
 
@@ -100,10 +100,10 @@ class VariableNode : public Node {
 class AuxNode : public Node {
  public:
   // Overloaded constructors for ease of use
-  AuxNode(nnvmNodePtr node, const std::string& name)
+  AuxNode(nnvmNodePtr node, const std::string &name)
       : Node(NodeType::kAux, node, name) {}
-  AuxNode(nnvmNodePtr node, const std::string& name,
-          const std::vector<NodePtr>& inputs)
+  AuxNode(nnvmNodePtr node, const std::string &name,
+          const std::vector<NodePtr> &inputs)
       : Node(NodeType::kAux, node, name, inputs) {}
 };
 
@@ -122,13 +122,13 @@ class OpNode : public Node {
   }
 
   // Overloaded constructors for ease of use
-  OpNode(nnvmNodePtr node, const std::string& name,
-         const std::string& operation)
+  OpNode(nnvmNodePtr node, const std::string &name,
+         const std::string &operation)
       : Node(NodeType::kOp, node, name) {
     operation_ = operation;
   }
-  OpNode(nnvmNodePtr node, const std::string& name,
-         const std::string& operation, const std::vector<NodePtr>& inputs)
+  OpNode(nnvmNodePtr node, const std::string &name,
+         const std::string &operation, const std::vector<NodePtr> &inputs)
       : Node(NodeType::kOp, node, name, inputs) {
     operation_ = operation;
   }
@@ -137,26 +137,30 @@ class OpNode : public Node {
 // makes sure you have only one manager of one type
 static std::shared_ptr<ngraph::runtime::Manager> nbridge_backend_manager_;
 static std::shared_ptr<ngraph::runtime::Backend> nbridge_backend_;
-static std::unordered_map< std::string,std::shared_ptr<ngraph::runtime::Manager> > backend_managers = 
-	{{"NGVM", ngraph::runtime::Manager::get("NGVM")}, {"ARGON", nullptr},{"CPU", nullptr},{"GPU", nullptr}};
-   inline std::shared_ptr<ngraph::runtime::Manager> GetManagerFromContext(
-    const mxnet::Context& context) {
-    std::string backend = (context == mxnet::Context::NNP()) ? "ARGON" : "NGVM";
-    if (backend_managers[backend] == nullptr) {
-      backend_managers[backend] = ngraph::runtime::Manager::get(backend);
-    }
-    nbridge_backend_manager_ = backend_managers[backend];
+static std::unordered_map<std::string,
+                          std::shared_ptr<ngraph::runtime::Manager>>
+    backend_managers = {{"NGVM", ngraph::runtime::Manager::get("NGVM")},
+                        {"ARGON", nullptr},
+                        {"CPU", nullptr},
+                        {"GPU", nullptr}};
+inline std::shared_ptr<ngraph::runtime::Manager> GetManagerFromContext(
+    const mxnet::Context &context) {
+  std::string backend = (context == mxnet::Context::NNP()) ? "ARGON" : "NGVM";
+  if (backend_managers[backend] == nullptr) {
+    backend_managers[backend] = ngraph::runtime::Manager::get(backend);
+  }
+  nbridge_backend_manager_ = backend_managers[backend];
 
-    return nbridge_backend_manager_;
+  return nbridge_backend_manager_;
 }
-   inline  std::shared_ptr<ngraph::runtime::Backend> GetBackendFromContext(
-    const mxnet::Context& context) {
-    if (!nbridge_backend_) {
-      nbridge_backend_ = nbridge_backend_manager_->allocate_backend();
-      return nbridge_backend_;
-    }
+inline std::shared_ptr<ngraph::runtime::Backend> GetBackendFromContext(
+    const mxnet::Context &context) {
+  if (!nbridge_backend_) {
+    nbridge_backend_ = nbridge_backend_manager_->allocate_backend();
     return nbridge_backend_;
   }
+  return nbridge_backend_;
+}
 
 /*
 Graph class
@@ -166,11 +170,9 @@ TODO: Refactor into Graph and subgraph?
 */
 class Graph : public Node {
  public:
-  Graph(const std::string& name = "",
-        const mxnet::Context& context = mxnet::Context::CPU())
-      : Node(NodeType::kGraph, nullptr, name),
-        context_(context)
-        {}
+  Graph(const std::string &name = "",
+        const mxnet::Context &context = mxnet::Context::CPU())
+      : Node(NodeType::kGraph, nullptr, name), context_(context) {}
 
   // Add a node to the graph
   void AddNode(NodePtr node) { nodes_.emplace_back(node); }
@@ -196,13 +198,13 @@ class Graph : public Node {
 /**
  * High level function that does the subgraph identification
  */
-void IdentifySubgraphs(Graph& graph, std::function<bool(NodePtr)> func);
+void IdentifySubgraphs(Graph &graph, std::function<bool(NodePtr)> func);
 
 /**
  * Convert graph from identified nodes to a network of nodes and graphs,
  * each graph node represented a combined ngraph operation
  */
-void CollapseSubgraphs(Graph& graph);
+void CollapseSubgraphs(Graph &graph);
 
 /**
  * Selection of nodes based on function criterion.
@@ -214,7 +216,7 @@ std::vector<NodePtr> SelectNodes(NodePtr node,
 /**
  * Finds simply connected ngraph operations
  */
-std::vector<NodePtr> FindSubgraph(Graph& graph, NodePtr node,
+std::vector<NodePtr> FindSubgraph(Graph &graph, NodePtr node,
                                   std::function<bool(NodePtr)> func);
 
 }  // namespace ngraph_bridge

--- a/src/ngraph/ngraph_nnvm_ops.cc
+++ b/src/ngraph/ngraph_nnvm_ops.cc
@@ -27,14 +27,14 @@
 namespace ngraph_bridge {
 
 // get the OP from nnvm, return a pointer to it.
-nnvm::Op* get_subgraph_op(std::shared_ptr<Graph> graph) {
+nnvm::Op *get_subgraph_op(std::shared_ptr<Graph> graph) {
   return &(::dmlc::Registry<::nnvm::Op>::Get()->__REGISTER_OR_GET__(
       "ngraph_" + graph->name_));
 }
 
 void register_forward_op(std::shared_ptr<Graph> graph) {
   // register the op with nnvm
-  auto& op = ::dmlc::Registry<::nnvm::Op>::Get()->__REGISTER_OR_GET__(
+  auto &op = ::dmlc::Registry<::nnvm::Op>::Get()->__REGISTER_OR_GET__(
       "ngraph_" + graph->name_);
   // setup the inputs and outpus
   int num_inputs = graph->inputs_.size();
@@ -51,7 +51,7 @@ void register_forward_op(std::shared_ptr<Graph> graph) {
   // register lambda to list inputs
   op.set_attr<nnvm::FListInputNames>(
       "FListInputNames",
-      [input_names](const nnvm::NodeAttrs& attrs) { return input_names; });
+      [input_names](const nnvm::NodeAttrs &attrs) { return input_names; });
 
   // // get the auxillary inputs
   std::vector<uint32_t> mutate_vars;
@@ -64,10 +64,10 @@ void register_forward_op(std::shared_ptr<Graph> graph) {
   // register lambda to list inputs
   op.set_attr<nnvm::FMutateInputs>(
       "FMutateInputs",
-      [mutate_vars](const nnvm::NodeAttrs& attrs) { return mutate_vars; });
+      [mutate_vars](const nnvm::NodeAttrs &attrs) { return mutate_vars; });
 
   // dummy attribute parser for execution
-  auto attr_parser = [](nnvm::NodeAttrs* attrs) {
+  auto attr_parser = [](nnvm::NodeAttrs *attrs) {
     if (attrs->parsed.empty()) {
       NGraphParam op;
       attrs->parsed = std::move(op);
@@ -77,7 +77,7 @@ void register_forward_op(std::shared_ptr<Graph> graph) {
 
   // register lambda to say nothing is inplace
   op.set_attr<nnvm::FInplaceOption>("FInplaceOption",
-                                    [num_inputs](const nnvm::NodeAttrs& attrs) {
+                                    [num_inputs](const nnvm::NodeAttrs &attrs) {
                                       std::vector<std::pair<int, int>> inplace;
                                       for (int i = 0; i < num_inputs; ++i)
                                         inplace.push_back({i, 0});
@@ -86,7 +86,7 @@ void register_forward_op(std::shared_ptr<Graph> graph) {
 
   // register another lambda to say nothing is in place
   op.set_attr<nnvm::FInplaceIdentity>(
-      "FInplaceIdentity", [num_inputs](const nnvm::NodeAttrs& attrs) {
+      "FInplaceIdentity", [num_inputs](const nnvm::NodeAttrs &attrs) {
         std::vector<bool> inplace;
         for (int i = 0; i < num_inputs; ++i) inplace.push_back(false);
         return inplace;
@@ -95,8 +95,8 @@ void register_forward_op(std::shared_ptr<Graph> graph) {
   // Register Gradient node generation function
   auto back_op_name = "_backward_" + ("ngraph_" + graph->name_);
   op.set_attr<nnvm::FGradient>(
-      "FGradient", [back_op_name](const nnvm::NodePtr& n,
-                                  const std::vector<nnvm::NodeEntry>& ograds) {
+      "FGradient", [back_op_name](const nnvm::NodePtr &n,
+                                  const std::vector<nnvm::NodeEntry> &ograds) {
         auto p = nnvm::Node::Create();
         p->attrs.op = nnvm::Op::Get(back_op_name);
         p->attrs.name = n->attrs.name + "_backward";
@@ -123,8 +123,8 @@ void register_forward_op(std::shared_ptr<Graph> graph) {
   auto dtype = graph->dtype_;
   op.set_attr<nnvm::FInferShape>(
       "FInferShape",
-      [shape](const nnvm::NodeAttrs& attrs, std::vector<nnvm::TShape>* in_attrs,
-              std::vector<nnvm::TShape>* out_attrs) -> bool {
+      [shape](const nnvm::NodeAttrs &attrs, std::vector<nnvm::TShape> *in_attrs,
+              std::vector<nnvm::TShape> *out_attrs) -> bool {
         (*out_attrs)[0] = shape;
         return true;
       });
@@ -132,22 +132,22 @@ void register_forward_op(std::shared_ptr<Graph> graph) {
   // similarly bad
   op.set_attr<nnvm::FInferType>(
       "FInferType",
-      [dtype](const nnvm::NodeAttrs& attrs, std::vector<int>* iattr,
-              std::vector<int>* oattr) -> bool {
+      [dtype](const nnvm::NodeAttrs &attrs, std::vector<int> *iattr,
+              std::vector<int> *oattr) -> bool {
         return mxnet::op::type_assign(&((*oattr)[0]), dtype);
       });
 
   // create the compute lambda
   op.set_attr<mxnet::FCompute>(
       "FCompute<cpu>",
-      [graph](const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
-              const std::vector<mxnet::TBlob>& inputs,
-              const std::vector<mxnet::OpReqType>& req,
-              const std::vector<mxnet::TBlob>& outputs) -> void {
-        auto placeholders =
-            make_ngraph_placeholders(inputs, GetBackendFromContext(graph->context_), true);
-        auto results =
-            make_ngraph_placeholders(outputs, GetBackendFromContext(graph->context_), false);
+      [graph](const nnvm::NodeAttrs &attrs, const mxnet::OpContext &ctx,
+              const std::vector<mxnet::TBlob> &inputs,
+              const std::vector<mxnet::OpReqType> &req,
+              const std::vector<mxnet::TBlob> &outputs) -> void {
+        auto placeholders = make_ngraph_placeholders(
+            inputs, GetBackendFromContext(graph->context_), true);
+        auto results = make_ngraph_placeholders(
+            outputs, GetBackendFromContext(graph->context_), false);
         graph->ngraph_forward->call(placeholders, results);
         result_to_TBlob(results[0], outputs, 0);
       });
@@ -155,7 +155,7 @@ void register_forward_op(std::shared_ptr<Graph> graph) {
 
 void register_backward_op(std::shared_ptr<Graph> graph) {
   // register the op with nnvm
-  auto& op = ::dmlc::Registry<::nnvm::Op>::Get()->__REGISTER_OR_GET__(
+  auto &op = ::dmlc::Registry<::nnvm::Op>::Get()->__REGISTER_OR_GET__(
       "_backward_" + ("ngraph_" + graph->name_));
   // setup the inputs and outpus
   int num_inputs = graph->inputs_.size();
@@ -163,7 +163,7 @@ void register_backward_op(std::shared_ptr<Graph> graph) {
   op.set_num_outputs(num_inputs);
 
   // dummy attribute parser for execution
-  auto attr_parser = [](nnvm::NodeAttrs* attrs) {
+  auto attr_parser = [](nnvm::NodeAttrs *attrs) {
     if (attrs->parsed.empty()) {
       NGraphParam op;
       attrs->parsed = std::move(op);
@@ -176,14 +176,14 @@ void register_backward_op(std::shared_ptr<Graph> graph) {
   // create the compute lambda
   op.set_attr<mxnet::FCompute>(
       "FCompute<cpu>",
-      [graph](const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
-              const std::vector<mxnet::TBlob>& inputs,
-              const std::vector<mxnet::OpReqType>& req,
-              const std::vector<mxnet::TBlob>& outputs) -> void {
-        auto placeholders =
-            make_ngraph_placeholders(inputs, GetBackendFromContext(graph->context_), true);
-        auto results =
-            make_ngraph_placeholders(outputs, GetBackendFromContext(graph->context_), false);
+      [graph](const nnvm::NodeAttrs &attrs, const mxnet::OpContext &ctx,
+              const std::vector<mxnet::TBlob> &inputs,
+              const std::vector<mxnet::OpReqType> &req,
+              const std::vector<mxnet::TBlob> &outputs) -> void {
+        auto placeholders = make_ngraph_placeholders(
+            inputs, GetBackendFromContext(graph->context_), true);
+        auto results = make_ngraph_placeholders(
+            outputs, GetBackendFromContext(graph->context_), false);
         graph->ngraph_backward->call(placeholders,
                                      {ngraph::runtime::make_tuple(results)});
         for (size_t j = 0; j < results.size(); ++j)

--- a/src/ngraph/ngraph_sgcompiler.cc
+++ b/src/ngraph/ngraph_sgcompiler.cc
@@ -65,8 +65,10 @@ void SGCompiler::CompileSubgraph(std::shared_ptr<Graph> sub_graph) {
 
   // compile it into a call frame with the backend, and save
   // the compile frame into the subgraph
-  auto forward_external = GetManagerFromContext(sub_graph->context_)->compile(f);
-  sub_graph->ngraph_forward = GetBackendFromContext(sub_graph->context_)->make_call_frame(forward_external);
+  auto forward_external =
+      GetManagerFromContext(sub_graph->context_)->compile(f);
+  sub_graph->ngraph_forward = GetBackendFromContext(sub_graph->context_)
+                                  ->make_call_frame(forward_external);
 
   // Compile the backward Pass
   auto Y = f->get_result();
@@ -75,16 +77,17 @@ void SGCompiler::CompileSubgraph(std::shared_ptr<Graph> sub_graph) {
 
   std::vector<NgraphNodePtr> dYdXs(parameters.size());
   transform(parameters.begin(), parameters.end(), dYdXs.begin(),
-            [C, Y](const NgraphNodePtr& X) { return Y->backprop_node(X, C); });
+            [C, Y](const NgraphNodePtr &X) { return Y->backprop_node(X, C); });
 
   auto result = std::make_shared<ngraph::op::Tuple>(dYdXs);
   parameters.insert(parameters.begin(), C);
   auto bf = std::make_shared<ngraph::Function>(result, result->get_value_type(),
                                                parameters);
 
-  auto backward_external = GetManagerFromContext(sub_graph->context_)->compile(bf);
-  sub_graph->ngraph_backward =
-      GetBackendFromContext(sub_graph->context_)->make_call_frame(backward_external);
+  auto backward_external =
+      GetManagerFromContext(sub_graph->context_)->compile(bf);
+  sub_graph->ngraph_backward = GetBackendFromContext(sub_graph->context_)
+                                   ->make_call_frame(backward_external);
 }
 
 // compiling a node, recursively checking it's inputs


### PR DESCRIPTION
## Description ##
I have resolved this issue with multiple instances on the Argon backend.  Essentially what I did is remove the data members for storing the backend and manager for Argon.  We already have global variable that is being handled by the respective functions.  There is no need to have a separate variable to work on its behalf.  There is still an error, but it is not in the bridge code.

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [X ] Changes are complete (i.e. I finished coding on this PR)
- [X ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated.
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Intersting edge cases to note here