### PR TITLE
emit relu directly

### DIFF
--- a/src/ngraph/ngraph_emitter.cc
+++ b/src/ngraph/ngraph_emitter.cc
@@ -142,9 +142,7 @@ void Emitter::CreateUnaryOps() {
     return ngraph_op_funcs_[act_type](node);
   };
   ngraph_op_funcs_["relu"] = [this](const NodePtr& node) {
-    auto zero = makeConstant(node, "0");
-    return std::make_shared<ngraph::op::Maximum>(op_map_[node->inputs_[0]],
-                                                 zero);
+    return std::make_shared<ngraph::op::Relu>(op_map_[node->inputs_[0]]);
   };
   ngraph_op_funcs_["sigmoid"] = [this](const NodePtr& node) {
     auto one = makeConstant(node, "1");


### PR DESCRIPTION
## Description ##
Replace the current decomposition of `Relu` -> `max(0,X)` to use the new `Relu` op in ngraph core  

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
