### PR TITLE
Update the sample_num = 20

### DIFF
--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -1155,7 +1155,7 @@ def gen_binary_data_int(dummy):
 
 
 def check_binary_op_forward(symbol, baseline, gen_data, rtol=1e-3, atol=1e-5, mx_nd_func=None):
-    sample_num = 200
+    sample_num = 20
     for i in range(sample_num):
         d = gen_data(i)
         x = baseline(d[0], d[1])
@@ -1183,7 +1183,7 @@ def check_binary_op_forward(symbol, baseline, gen_data, rtol=1e-3, atol=1e-5, mx
 
 
 def check_binary_op_backward(symbol, baseline, gen_data, rtol=1e-3, atol=1e-5):
-    sample_num = 200
+    sample_num = 20
     for i in range(sample_num):
         d = gen_data(i)
         out = np.random.random((d[0] + d[1]).shape)


### PR DESCRIPTION
Modified line 1158 :  sample_num = 20 in check_binary_op_forward()
Modified line 1186 :  sample_num = 20 in check_binary_op_backward()

## Description ##
Modified line 1158 :  sample_num = 20 in check_binary_op_forward()
Modified line 1186 :  sample_num = 20 in check_binary_op_backward()

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here