### PR TITLE
Fixes NGMX-331: Use nGraph++ AvgPool op

### DIFF
--- a/src/ngraph/ngraph_compiler.cc
+++ b/src/ngraph/ngraph_compiler.cc
@@ -19,6 +19,7 @@
 #include <nnvm/node.h>
 #include <nnvm/pass.h>
 #include <algorithm>
+#include <set>
 #include "../executor/exec_pass.h"
 #include "ngraph_compiler.h"
 #include "ngraph_nnvm_ops.h"
@@ -309,14 +310,19 @@ void Compiler::CheckInNgraph() {
     if (node->type_ == NodeType::kOp) {
       if (compiler_.ngraph_op_funcs_.count(node->operation_)) {
         node->in_ngraph_ = true;
-        // TODO(mbrookhart): Enable average and sum Pooling
-        if ((node->operation_ == "Pooling") &&
-            (get_default(node, "pool_type", std::string("max")) != "max")) {
-          node->in_ngraph_ = false;
+        // TODO(mbrookhart): Enable sum Pooling
+        if (node->operation_ == "Pooling") {
+          const std::string pooling_type = get_default(node, "pool_type", std::string("max"));
+          static const std::set<std::string> supported_pooling_types = {
+            "avg",
+            "max",
+          };
+          if (supported_pooling_types.find(pooling_type) == supported_pooling_types.end()) {
+            node->in_ngraph_ = false;
+          }
         }
         if (node->dtype_ == mshadow::kFloat16) {
           node->in_ngraph_ = false;
-
         } else {
           for (auto input : node->inputs_) {
             if (input->dtype_ == mshadow::kFloat16) {

--- a/src/ngraph/ngraph_emitter.cc
+++ b/src/ngraph/ngraph_emitter.cc
@@ -934,16 +934,12 @@ void Emitter::CreateLayerOps() {
   };
   ngraph_op_funcs_["avg_pooling"] = [this,
                                      &asymetric_padding](const NodePtr& node) {
-    // TODO(mbrookhart): Re-enable average pooling when supported in nGraph
-    throw std::runtime_error(
-        "NGRAPH_BRIDGE: nGraph doesn't yet support MXNet's avg pooling "
-        "convention with padding");
     auto input = op_map_[node->inputs_[0]];
     auto params = PoolingParams(node, input);
 
     return std::make_shared<ngraph::op::AvgPool>(
         input, params.kernel, params.stride, params.pad,
-        asymetric_padding(input->get_shape(), params));
+        asymetric_padding(input->get_shape(), params), true);
   };
 }
 


### PR DESCRIPTION
## Description ##
Update bridge code to use nGraph++'s `AvgPool` operator.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (~`make lint`~ `make cpplint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Added construction of `ngraph::op::AvgPool` object, and enabled it in `Compiler::CheckInNgraph()`.  Tested by successfully running these commands:
``` bash
pytest -k test_pooling_versions test_operator_gpu.py
pytest -k test_pooling_with_type test_operator_gpu.py
```
on `nervana-titanxp50` with a CUDA-enabled build of MXNet.
