### PR TITLE
Ngmx_328 and NGMX_379 - Add sparse type and ndarray integration to ngraph_bridge

### DIFF
--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -1181,7 +1181,7 @@ Graph GraphExecutor::InitGraph(nnvm::Symbol symbol,
 
   nnvm::Graph g;
   g.outputs = symbol.outputs;
-// setup gradient
+  // setup gradient
 #if MXNET_USE_NGRAPH == 0
   g = InitFullGraph(g, symbol.ListInputs(nnvm::Symbol::kReadOnlyArgs),
                     grad_req_types);

--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -25,13 +25,13 @@
 #include <mxnet/base.h>
 #include <nnvm/graph.h>
 #include <nnvm/pass_functions.h>
-#include <algorithm>
 #include <vector>
+#include <algorithm>
 
-#include "../common/utils.h"
-#include "../engine/profiler.h"
 #include "./exec_pass.h"
 #include "./graph_executor.h"
+#include "../engine/profiler.h"
+#include "../common/utils.h"
 
 #if MXNET_USE_NGRAPH == 1
 #include "../ngraph/ngraph_compiler.h"
@@ -58,8 +58,8 @@ GraphExecutor::~GraphExecutor() {
   }
 }
 
-inline NDArray InitZeros(const NDArrayStorageType stype, const TShape& shape,
-                         const Context& ctx, const int dtype) {
+inline NDArray InitZeros(const NDArrayStorageType stype, const TShape &shape,
+                                const Context &ctx, const int dtype) {
   // NDArray with default storage
   if (stype == kDefaultStorage) {
     NDArray ret(shape, ctx, false, dtype);
@@ -70,9 +70,9 @@ inline NDArray InitZeros(const NDArrayStorageType stype, const TShape& shape,
   return NDArray(stype, shape, ctx, true, dtype);
 }
 
-inline void EmplaceBackZeros(const NDArrayStorageType stype,
-                             const TShape& shape, const Context& ctx,
-                             const int dtype, std::vector<NDArray>* vec) {
+inline void EmplaceBackZeros(const NDArrayStorageType stype, const TShape &shape,
+                             const Context &ctx, const int dtype,
+                             std::vector<NDArray> *vec) {
   // NDArray with default storage
   if (stype == kDefaultStorage) {
     vec->emplace_back(shape, ctx, false, dtype);
@@ -86,18 +86,16 @@ void GraphExecutor::Forward(bool is_train) {
   RunOps(is_train, 0, num_forward_nodes_);
 }
 
-void GraphExecutor::PartialForward(bool is_train, int step, int* step_left) {
+void GraphExecutor::PartialForward(bool is_train, int step, int *step_left) {
   size_t sstep = static_cast<size_t>(step);
   if (sstep >= num_forward_nodes_) {
-    *step_left = 0;
-    return;
+    *step_left = 0; return;
   }
   RunOps(is_train, sstep, sstep + 1);
   *step_left = static_cast<int>(num_forward_nodes_ - sstep - 1);
 }
 
-void GraphExecutor::Backward(const std::vector<NDArray>& head_grads,
-                             bool is_train) {
+void GraphExecutor::Backward(const std::vector<NDArray>& head_grads, bool is_train) {
   const auto& idx = graph_.indexed_graph();
   if (num_forward_inputs_ != idx.input_nodes().size()) {
     for (size_t i = 0; i < head_grad_array_.size(); ++i) {
@@ -115,13 +113,12 @@ void GraphExecutor::Backward(const std::vector<NDArray>& head_grads,
   RunOps(is_train, num_forward_nodes_, idx.num_nodes());
 }
 
-void GraphExecutor::Print(std::ostream& os) const {  // NOLINT(*)
-  nnvm::Symbol s;
-  s.outputs = graph_.outputs;
+void GraphExecutor::Print(std::ostream &os) const {  // NOLINT(*)
+  nnvm::Symbol s; s.outputs = graph_.outputs;
   s.Print(os);
   // message to be backward compatible with the memonger
   size_t total_bytes = graph_.GetAttr<size_t>("storage_allocated_bytes");
-  os << "Total " << (total_bytes >> 20UL) << " MB allocated\n";
+  os << "Total " << (total_bytes >> 20UL) <<" MB allocated\n";
   os << "Total " << 11 << " TempSpace resource requested\n";
 }
 
@@ -134,18 +131,15 @@ const std::vector<NDArray>& GraphExecutor::outputs() const {
   return output_arrays_;
 }
 
-const std::unordered_map<std::string, NDArray>& GraphExecutor::in_arg_map()
-    const {
+const std::unordered_map<std::string, NDArray>& GraphExecutor::in_arg_map() const {
   return in_arg_map_;
 }
 
-const std::unordered_map<std::string, NDArray>& GraphExecutor::arg_grad_map()
-    const {
+const std::unordered_map<std::string, NDArray>& GraphExecutor::arg_grad_map() const {
   return arg_grad_map_;
 }
 
-const std::unordered_map<std::string, NDArray>& GraphExecutor::aux_state_map()
-    const {
+const std::unordered_map<std::string, NDArray>& GraphExecutor::aux_state_map() const {
   return aux_state_map_;
 }
 
@@ -160,8 +154,7 @@ static nnvm::NodeEntry AttrHint(nnvm::NodeEntry src, nnvm::NodeEntry like) {
 
 nnvm::NodeEntry AggregateGradient(std::vector<nnvm::NodeEntry>&& v) {
   using nnvm::Op;
-  static size_t inplace_sum_cap =
-      dmlc::GetEnv("MXNET_EXEC_INPLACE_GRAD_SUM_CAP", 8);
+  static size_t inplace_sum_cap = dmlc::GetEnv("MXNET_EXEC_INPLACE_GRAD_SUM_CAP", 8);
   static const Op* ewise_plus_op = Op::Get("_grad_add");
   static const Op* ewise_sum_op = Op::Get("ElementWiseSum");
   static const Op* identity_op = Op::Get("identity");
@@ -177,11 +170,9 @@ nnvm::NodeEntry AggregateGradient(std::vector<nnvm::NodeEntry>&& v) {
   }
 
   // remove zero in the sum. at least keep 1.
-  auto begin =
-      std::remove_if(v.begin(), v.end(), [](const nnvm::NodeEntry& nodeEntry) {
-        return nodeEntry.node->op() == zeros_op ||
-               nodeEntry.node->op() == zeros_like_op;
-      });
+  auto begin = std::remove_if(v.begin(), v.end(), [](const nnvm::NodeEntry& nodeEntry) {
+     return nodeEntry.node->op() == zeros_op || nodeEntry.node->op() == zeros_like_op;
+  });
   if (begin == v.begin()) ++begin;
   v.erase(begin, v.end());
   CHECK(!v.empty());
@@ -204,12 +195,10 @@ nnvm::NodeEntry AggregateGradient(std::vector<nnvm::NodeEntry>&& v) {
         // Add control flow dependency from to previous node
         // This enforces the gradient sum order will be in the inverse
         // order of forward traversal
-        // NOTE: adding control dependency can be dangerous and cause cycle in
-        // the dep.
+        // NOTE: adding control dependency can be dangerous and cause cycle in the dep.
         // The curent usage is correct, because of the following invariant:
         // assert: v[i-1] do not depend on v[i]
-        // To put in plain text: v is gradient vector that get pushed in the
-        // order
+        // To put in plain text: v is gradient vector that get pushed in the order
         // that can generate them, which means if v[i] is not yet pushed,
         // all previous gradient cannot depend on it.
         // Note: For a symbol like the following:
@@ -218,7 +207,7 @@ nnvm::NodeEntry AggregateGradient(std::vector<nnvm::NodeEntry>&& v) {
         // the node entries v passed in here are of the same node of
         // op _identity_with_attr_like_rhs. We should skip adding a node
         // to its own control_deps.
-        if (v[i - 1].node != v[i].node) {
+        if (v[i-1].node != v[i].node) {
           v[i].node->control_deps.push_back(ret.node);
         }
 
@@ -241,9 +230,10 @@ nnvm::NodeEntry AggregateGradient(std::vector<nnvm::NodeEntry>&& v) {
   }
 }
 
-template <typename ValueType>
-inline ValueType get_node_attr(const nnvm::Node& node, const std::string& key,
-                               ValueType default_value) {
+template<typename ValueType>
+inline ValueType get_node_attr(
+    const nnvm::Node& node,
+    const std::string& key, ValueType default_value) {
   auto it = node.attrs.dict.find(key);
   if (it == node.attrs.dict.end()) {
     return default_value;
@@ -261,9 +251,9 @@ inline ValueType get_node_attr(const nnvm::Node& node, const std::string& key,
  * This is triggered by both simple_bind and bind flows.
  */
 
-nnvm::Graph GraphExecutor::InitFullGraph(
-    nnvm::Graph g, std::vector<nnvm::NodePtr> args,
-    const std::vector<OpReqType>& grad_req_types) {
+
+nnvm::Graph GraphExecutor::InitFullGraph(nnvm::Graph g, std::vector<nnvm::NodePtr> args,
+                                         const std::vector<OpReqType>& grad_req_types) {
   using nnvm::NodePtr;
   using nnvm::NodeEntry;
   // initial information
@@ -306,11 +296,12 @@ nnvm::Graph GraphExecutor::InitFullGraph(
   zero_ops.push_back(nnvm::Op::Get("_zeros"));
 
   // take gradient
-  nnvm::Graph g_grad = nnvm::pass::Gradient(g, g.outputs, xs, head_grad_entry_,
-                                            AggregateGradient, need_mirror,
-                                            nullptr, zero_ops, "_copy");
+  nnvm::Graph g_grad = nnvm::pass::Gradient(
+      g, g.outputs, xs, head_grad_entry_,
+      AggregateGradient, need_mirror, nullptr,
+      zero_ops, "_copy");
   CHECK_EQ(g_grad.outputs.size(), xs.size());
-  for (const auto& e : g_grad.outputs) {
+  for (const auto &e : g_grad.outputs) {
     g.outputs.push_back(e);
   }
   return g;
@@ -320,14 +311,15 @@ nnvm::Graph GraphExecutor::InitFullGraph(
  * \brief Assign context to the graph.
  * This is triggered by both simple_bind and bind flows.
  */
-static Graph AssignContext(Graph g, const Context& default_ctx,
-                           const std::map<std::string, Context>& ctx_map,
-                           const std::vector<Context>& in_arg_ctxes,
-                           const std::vector<Context>& arg_grad_ctxes,
-                           const std::vector<Context>& aux_state_ctxes,
-                           const std::vector<OpReqType>& grad_req_types,
-                           size_t num_forward_inputs,
-                           size_t num_forward_outputs) {
+static Graph AssignContext(Graph g,
+                    const Context& default_ctx,
+                    const std::map<std::string, Context>& ctx_map,
+                    const std::vector<Context>& in_arg_ctxes,
+                    const std::vector<Context>& arg_grad_ctxes,
+                    const std::vector<Context>& aux_state_ctxes,
+                    const std::vector<OpReqType>& grad_req_types,
+                    size_t num_forward_inputs,
+                    size_t num_forward_outputs) {
   const auto& idx = g.indexed_graph();
   const auto& mutable_nodes = idx.mutable_input_nodes();
   // default use default context.
@@ -336,35 +328,31 @@ static Graph AssignContext(Graph g, const Context& default_ctx,
         ContextVector(idx.num_nodes(), default_ctx));
     for (const auto& x : in_arg_ctxes) {
       CHECK(x == default_ctx)
-          << "Input array is in " << x
-          << " while binding with ctx=" << default_ctx
-          << ". All arguments must be in global context (" << default_ctx
-          << ") unless group2ctx is specified for cross-device graph.";
+        << "Input array is in " << x << " while binding with ctx=" << default_ctx
+        << ". All arguments must be in global context (" << default_ctx
+        << ") unless group2ctx is specified for cross-device graph.";
     }
     for (const auto& x : arg_grad_ctxes) {
       CHECK(x == default_ctx)
-          << "Gradient array is in " << x
-          << " while binding with ctx=" << default_ctx
-          << ". All gradients must be in global context (" << default_ctx
-          << ") unless group2ctx is specified for cross-device graph.";
+        << "Gradient array is in " << x << " while binding with ctx="
+        << default_ctx << ". All gradients must be in global context (" << default_ctx
+        << ") unless group2ctx is specified for cross-device graph.";
     }
     return g;
   }
 
   // otherwise, use context assignment.
-  std::map<Context, int> ctx2id;                   // map ctx to device id
-  std::vector<Context> ctx_list;                   // index is device id
+  std::map<Context, int> ctx2id;  // map ctx to device id
+  std::vector<Context> ctx_list;  // index is device id
   nnvm::DeviceVector device(idx.num_nodes(), -1);  // index is node id
-  nnvm::DeviceAssignMap device_map;                // map arg name to device id
+  nnvm::DeviceAssignMap device_map;  // map arg name to device id
 
   // loop through the user input ctx_map and
   // populate maps and lists
-  for (auto& kv : ctx_map) {
-    if (ctx2id.count(kv.second) ==
-        0) {  // if context has no device id, create one
-      ctx2id[kv.second] =
-          static_cast<int>(ctx_list.size());  // assign device id to ctx
-      ctx_list.push_back(kv.second);          // save ctx to the list
+  for (auto &kv : ctx_map) {
+    if (ctx2id.count(kv.second) == 0) {  // if context has no device id, create one
+      ctx2id[kv.second] = static_cast<int>(ctx_list.size());  // assign device id to ctx
+      ctx_list.push_back(kv.second);  // save ctx to the list
     }
     // assign device id to to the arg name with the corresponding ctx
     device_map[kv.first] = ctx2id.at(kv.second);
@@ -385,10 +373,8 @@ static Graph AssignContext(Graph g, const Context& default_ctx,
       ctx = in_arg_ctxes[arg_top];
       ++arg_top;
     }
-    if (ctx2id.count(ctx) ==
-        0) {  // if the current ctx is not in the map of ctx and device id
-      ctx2id[ctx] = static_cast<int>(
-          ctx_list.size());     // assign the current ctx with device id
+    if (ctx2id.count(ctx) == 0) {  // if the current ctx is not in the map of ctx and device id
+      ctx2id[ctx] = static_cast<int>(ctx_list.size());  // assign the current ctx with device id
       ctx_list.push_back(ctx);  // save the current ctx in the list
     }
     device[nid] = ctx2id.at(ctx);  // assign device id to the current node
@@ -400,9 +386,8 @@ static Graph AssignContext(Graph g, const Context& default_ctx,
   // keep an offset into the arg_grad_ctxes vector,
   // since g.outputs exclude arg_grad whose req == null
   CHECK_GE(grad_req_types.size(), g.outputs.size() - num_forward_outputs)
-      << "insufficient number of grad_reqs";
-  for (size_t i = num_forward_outputs; i < g.outputs.size();
-       ++i, ++arg_grad_offset) {
+           << "insufficient number of grad_reqs";
+  for (size_t i = num_forward_outputs; i < g.outputs.size(); ++i, ++arg_grad_offset) {
     while (grad_req_types[arg_grad_offset] == kNullOp) ++arg_grad_offset;
     const uint32_t nid = idx.outputs()[i].node_id;
     Context ctx = arg_grad_ctxes[arg_grad_offset];
@@ -412,16 +397,14 @@ static Graph AssignContext(Graph g, const Context& default_ctx,
     }
     int devid = ctx2id.at(ctx);
     if (device[nid] != -1) {
-      CHECK_EQ(device[nid], devid)
-          << "device of same output not equal to each other";
+      CHECK_EQ(device[nid], devid) << "device of same output not equal to each other";
     } else {
       device[nid] = devid;
     }
   }
 
   g.attrs["device"] = std::make_shared<dmlc::any>(std::move(device));
-  g = nnvm::pass::PlaceDevice(g, "__ctx_group__", device_map,
-                              "_CrossDeviceCopy");
+  g = nnvm::pass::PlaceDevice(g, "__ctx_group__", device_map, "_CrossDeviceCopy");
   const auto& assigned_device = g.GetAttr<nnvm::DeviceVector>("device");
 
   ContextVector vcontext;
@@ -436,17 +419,17 @@ static Graph AssignContext(Graph g, const Context& default_ctx,
   // after device planning, we should check again
   // if the assigned device of gradient node
   // corresponds to storage of grads
-  auto& new_idx = g.indexed_graph();
+  auto &new_idx = g.indexed_graph();
   arg_grad_offset = 0;
-  for (size_t i = num_forward_outputs; i < g.outputs.size();
-       ++i, ++arg_grad_offset) {
+  for (size_t i = num_forward_outputs; i < g.outputs.size(); ++i, ++arg_grad_offset) {
     while (grad_req_types[arg_grad_offset] == kNullOp) ++arg_grad_offset;
     const uint32_t nid = new_idx.outputs()[i].node_id;
     Context ctx = arg_grad_ctxes[arg_grad_offset];
     CHECK(ctx == vcontext[nid])
-        << "Trying to save gradient to " << ctx << " while its source node \""
-        << new_idx[nid].source->attrs.name << "\" computes it on "
-        << vcontext[nid] << ". Check your ctx in NDArray allocation.";
+      << "Trying to save gradient to " << ctx
+      << " while its source node \"" << new_idx[nid].source->attrs.name
+      << "\" computes it on " << vcontext[nid]
+      << ". Check your ctx in NDArray allocation.";
   }
 
   g.attrs["context"] = std::make_shared<nnvm::any>(std::move(vcontext));
@@ -454,8 +437,8 @@ static Graph AssignContext(Graph g, const Context& default_ctx,
 }
 
 static void HandleInferShapeError(const size_t num_forward_inputs,
-                                  const nnvm::IndexedGraph& idx,
-                                  const nnvm::ShapeVector& inferred_shapes) {
+                           const nnvm::IndexedGraph& idx,
+                           const nnvm::ShapeVector& inferred_shapes) {
   int cnt = 10;
   std::ostringstream oss;
   for (size_t i = 0; i < num_forward_inputs; ++i) {
@@ -471,16 +454,14 @@ static void HandleInferShapeError(const size_t num_forward_inputs,
       }
     }
   }
-  LOG(FATAL)
-      << "InferShape pass cannot decide shapes for the following arguments "
-         "(0s means unknown dimensions). Please consider providing them as "
-         "inputs:\n"
-      << oss.str();
+  LOG(FATAL) << "InferShape pass cannot decide shapes for the following arguments "
+                "(0s means unknown dimensions). Please consider providing them as inputs:\n"
+             << oss.str();
 }
 
 static void HandleInferTypeError(const size_t num_forward_inputs,
-                                 const nnvm::IndexedGraph& idx,
-                                 const nnvm::DTypeVector& inferred_dtypes) {
+                          const nnvm::IndexedGraph& idx,
+                          const nnvm::DTypeVector& inferred_dtypes) {
   int cnt = 10;
   std::ostringstream oss;
   for (size_t i = 0; i < num_forward_inputs; ++i) {
@@ -496,15 +477,14 @@ static void HandleInferTypeError(const size_t num_forward_inputs,
       }
     }
   }
-  LOG(FATAL)
-      << "InferType pass cannot decide dtypes for the following arguments "
-         "(-1 means unknown dtype). Please consider providing them as inputs:\n"
-      << oss.str();
+  LOG(FATAL) << "InferType pass cannot decide dtypes for the following arguments "
+                "(-1 means unknown dtype). Please consider providing them as inputs:\n"
+             << oss.str();
 }
 
-static void HandleInferStorageTypeError(
-    const size_t num_forward_inputs, const nnvm::IndexedGraph& idx,
-    const StorageTypeVector& inferred_stypes) {
+static void HandleInferStorageTypeError(const size_t num_forward_inputs,
+                                 const nnvm::IndexedGraph& idx,
+                                 const StorageTypeVector& inferred_stypes) {
   int cnt = 10;
   std::ostringstream oss;
   for (size_t i = 0; i < num_forward_inputs; ++i) {
@@ -520,11 +500,9 @@ static void HandleInferStorageTypeError(
       }
     }
   }
-  LOG(FATAL)
-      << "InferStorageType pass cannot decide storage type for the following "
-         "arguments "
-         "(-1 means unknown stype). Please consider providing them as inputs:\n"
-      << oss.str();
+  LOG(FATAL) << "InferStorageType pass cannot decide storage type for the following arguments "
+                "(-1 means unknown stype). Please consider providing them as inputs:\n"
+             << oss.str();
 }
 
 #if MXNET_USE_NGRAPH == 1
@@ -540,10 +518,8 @@ bool multi_context_check(const Context& default_ctx,
       }
     }
   }
-// TODO(mbrookhart): Ngraph doesn't support GPU yet, remove when the GPU
-// Transformer is read
-// When that happens, we probably also need to create collapsed nodes with
-// FCompute<gpu>
+  // TODO(mbrookhart): Ngraph doesn't support GPU yet, remove when the GPU Transformer is read
+  // When that happens, we probably also need to create collapsed nodes with FCompute<gpu>
 #if MXNET_USE_CUDA
   if (default_ctx == Context::GPU()) {
     multi_context = true;
@@ -566,7 +542,8 @@ bool grad_sparse_check(const std::vector<NDArray>& arg_grads) {
  * input arguments and gradients are provided by users. This initializer
  * uses the user provided NDArrays to populate data entries of the graph.
  */
-void GraphExecutor::Init(nnvm::Symbol symbol, const Context& default_ctx,
+void GraphExecutor::Init(nnvm::Symbol symbol,
+                         const Context& default_ctx,
                          const std::map<std::string, Context>& ctx_map,
                          const std::vector<NDArray>& in_args,
                          const std::vector<NDArray>& arg_grad_store,
@@ -581,14 +558,12 @@ void GraphExecutor::Init(nnvm::Symbol symbol, const Context& default_ctx,
     return nd.ctx();
   };
   std::vector<Context> in_arg_ctxes(in_args.size());
-  std::transform(in_args.begin(), in_args.end(), in_arg_ctxes.begin(),
-                 get_ctx1);
+  std::transform(in_args.begin(), in_args.end(), in_arg_ctxes.begin(), get_ctx1);
   std::vector<Context> arg_grad_ctxes(arg_grad_store.size());
-  std::transform(arg_grad_store.begin(), arg_grad_store.end(),
-                 arg_grad_ctxes.begin(), get_ctx2);
+  std::transform(arg_grad_store.begin(), arg_grad_store.end(), arg_grad_ctxes.begin(), get_ctx2);
   std::vector<Context> aux_state_ctxes(aux_states.size());
-  std::transform(aux_states.begin(), aux_states.end(), aux_state_ctxes.begin(),
-                 get_ctx1);
+  std::transform(aux_states.begin(), aux_states.end(), aux_state_ctxes.begin(), get_ctx1);
+
 
   nnvm::Graph g = InitGraph(symbol, default_ctx, ctx_map, in_arg_ctxes,
                             arg_grad_ctxes, aux_state_ctxes, grad_req_types);
@@ -597,7 +572,7 @@ void GraphExecutor::Init(nnvm::Symbol symbol, const Context& default_ctx,
   // TODO(mbrookhart): Remove this when hetr can handle multiple contexts
   auto multi_context = multi_context_check(default_ctx, in_arg_ctxes,
                                            arg_grad_ctxes, aux_state_ctxes);
-  auto grad_sparse = grad_sparse_check(arg_grad_store);
+  const auto grad_sparse = grad_sparse_check(arg_grad_store);
 
   ngraph_bridge::BindArg bind(num_forward_inputs_, in_args, aux_states);
   ngraph_bridge::Compiler compiler(
@@ -610,8 +585,7 @@ void GraphExecutor::Init(nnvm::Symbol symbol, const Context& default_ctx,
     // create "device" and "context" attrs for the graph
     g = InitFullGraph(g, compiler.GetInputs(), grad_req_types);
   } else {
-    g = InitFullGraph(g, symbol.ListInputs(nnvm::Symbol::kReadOnlyArgs),
-                      grad_req_types);
+    g = InitFullGraph(g, symbol.ListInputs(nnvm::Symbol::kReadOnlyArgs), grad_req_types);
   }
   g = AssignContext(g, default_ctx, ctx_map, in_arg_ctxes, arg_grad_ctxes,
                     aux_state_ctxes, grad_req_types, num_forward_inputs_,
@@ -656,8 +630,7 @@ void GraphExecutor::Init(nnvm::Symbol symbol, const Context& default_ctx,
         auto grad_oid = grad_store_.size() + num_forward_outputs_;
         auto grad_eid = idx.entry_id(idx.outputs()[grad_oid]);
         arg_stypes[grad_eid] = arg_grad_store[arg_top].storage_type();
-        grad_store_.emplace_back(grad_req_types[arg_top],
-                                 arg_grad_store[arg_top]);
+        grad_store_.emplace_back(grad_req_types[arg_top], arg_grad_store[arg_top]);
         arg_grad_map_.emplace(arg_name, arg_grad_store[arg_top]);
         if (log_verbose_) {
           LOG(INFO) << "\tassign data entry\t" << grad_eid << " as "
@@ -668,8 +641,7 @@ void GraphExecutor::Init(nnvm::Symbol symbol, const Context& default_ctx,
     }
     if (log_verbose_) {
       LOG(INFO) << "\tassign data entry\t" << eid << " as "
-                << common::stype_string(data_entry_[eid].storage_type())
-                << " (input)";
+                << common::stype_string(data_entry_[eid].storage_type()) << " (input)";
     }
   }
 
@@ -695,9 +667,9 @@ void GraphExecutor::Init(nnvm::Symbol symbol, const Context& default_ctx,
                                 g.GetAttr<StorageTypeVector>("storage_type"));
   }
 
-// Initialize the rest attributes of the graph.
-// This function can be called by regular bind
-// operation flow as well.
+  // Initialize the rest attributes of the graph.
+  // This function can be called by regular bind
+  // operation flow as well.
 #if MXNET_USE_NGRAPH == 1
   if (!multi_context && !grad_sparse) {
     FinishInitGraph(symbol, g, shared_exec, compiler.GetFeedDict());
@@ -736,8 +708,7 @@ void GraphExecutor::InitArguments(const nnvm::IndexedGraph& idx,
     const uint32_t eid = idx.entry_id(nid, 0);
     const TShape& inferred_shape = inferred_shapes[eid];
     const int inferred_dtype = inferred_dtypes[eid];
-    const NDArrayStorageType inferred_stype =
-        (NDArrayStorageType)inferred_stypes[eid];
+    const NDArrayStorageType inferred_stype = (NDArrayStorageType) inferred_stypes[eid];
     const std::string& arg_name = idx[nid].source->attrs.name;
     if (mutable_nodes.count(nid)) {  // aux_states
       EmplaceBackZeros(inferred_stype, inferred_shape, aux_state_ctxes[aux_top],
@@ -764,7 +735,7 @@ void GraphExecutor::InitArguments(const nnvm::IndexedGraph& idx,
         // Init based on storage type
         auto grad_oid = grad_store_.size() + num_forward_outputs_;
         auto grad_eid = idx.entry_id(idx.outputs()[grad_oid]);
-        auto grad_stype = (NDArrayStorageType)inferred_stypes[grad_eid];
+        auto grad_stype = (NDArrayStorageType) inferred_stypes[grad_eid];
         EmplaceBackZeros(grad_stype, inferred_shape, arg_grad_ctxes[arg_top],
                          inferred_dtype, arg_grad_vec);
         if (log_verbose_) {
@@ -788,11 +759,13 @@ void GraphExecutor::InitArguments(const nnvm::IndexedGraph& idx,
  * Shareable storages include both default storage and row_sparse storage
  * if enable_row_sparse_sharing is `True`, otherwise default storage only.
  */
-static NDArray ReshapeOrCreate(
-    const std::string& name, const TShape& dest_arg_shape,
-    const int dest_arg_dtype, const NDArrayStorageType dest_arg_stype,
-    const Context& ctx, std::unordered_map<std::string, NDArray>* shared_buffer,
-    bool enable_row_sparse_sharing) {
+static NDArray ReshapeOrCreate(const std::string& name,
+                        const TShape& dest_arg_shape,
+                        const int dest_arg_dtype,
+                        const NDArrayStorageType dest_arg_stype,
+                        const Context& ctx,
+                        std::unordered_map<std::string, NDArray>* shared_buffer,
+                        bool enable_row_sparse_sharing) {
   bool stype_shareable = dest_arg_stype == kDefaultStorage;
   if (enable_row_sparse_sharing) {
     stype_shareable = stype_shareable || dest_arg_stype == kRowSparseStorage;
@@ -803,24 +776,18 @@ static NDArray ReshapeOrCreate(
     bool size_shareable = it->second.shape().Size() >= dest_arg_shape.Size();
     if (size_shareable && stype_shareable) {  // memory can be reused
       CHECK_EQ(it->second.dtype(), dest_arg_dtype)
-          << "Requested arg array's dtype does not match that of the reusable "
-             "ndarray";
+        << "Requested arg array's dtype does not match that of the reusable ndarray";
       CHECK_EQ(it->second.storage_type(), dest_arg_stype)
-          << "Requested arg array's stype does not match that of the reusable "
-             "ndarray";
+        << "Requested arg array's stype does not match that of the reusable ndarray";
       return it->second.Reshape(dest_arg_shape);
     } else if (stype_shareable) {
-      LOG(WARNING)
-          << "Bucketing: data " << name << " has a shape " << dest_arg_shape
-          << ", which is larger than already allocated shape "
-          << it->second.shape()
-          << ". Need to re-allocate. Consider putting default bucket key to be "
-          << "the bucket taking the largest input for better memory sharing.";
+      LOG(WARNING) << "Bucketing: data " << name << " has a shape " << dest_arg_shape
+                   << ", which is larger than already allocated shape " << it->second.shape()
+                   << ". Need to re-allocate. Consider putting default bucket key to be "
+                   << "the bucket taking the largest input for better memory sharing.";
       // size is not large enough, creating a larger one for sharing
-      // the NDArrays in shared_buffer are guaranteed to be of shareable
-      // storages
-      it->second =
-          InitZeros(dest_arg_stype, dest_arg_shape, ctx, dest_arg_dtype);
+      // the NDArrays in shared_buffer are guaranteed to be of shareable storages
+      it->second = InitZeros(dest_arg_stype, dest_arg_shape, ctx, dest_arg_dtype);
       return it->second;
     } else {
       // not shareable storage
@@ -841,19 +808,20 @@ static NDArray ReshapeOrCreate(
  * shared_buffer from DataParallelExecutorGroup
  * and shared_exec if available.
  */
-void GraphExecutor::InitArguments(
-    const nnvm::IndexedGraph& idx, const nnvm::ShapeVector& inferred_shapes,
-    const nnvm::DTypeVector& inferred_dtypes,
-    const StorageTypeVector& inferred_stypes,
-    const std::vector<Context>& in_arg_ctxes,
-    const std::vector<Context>& arg_grad_ctxes,
-    const std::vector<Context>& aux_state_ctxes,
-    const std::vector<OpReqType>& grad_req_types,
-    const std::unordered_set<std::string>& shared_arg_names,
-    const Executor* shared_exec,
-    std::unordered_map<std::string, NDArray>* shared_buffer,
-    std::vector<NDArray>* in_arg_vec, std::vector<NDArray>* arg_grad_vec,
-    std::vector<NDArray>* aux_state_vec) {
+void GraphExecutor::InitArguments(const nnvm::IndexedGraph& idx,
+                                  const nnvm::ShapeVector& inferred_shapes,
+                                  const nnvm::DTypeVector& inferred_dtypes,
+                                  const StorageTypeVector& inferred_stypes,
+                                  const std::vector<Context>& in_arg_ctxes,
+                                  const std::vector<Context>& arg_grad_ctxes,
+                                  const std::vector<Context>& aux_state_ctxes,
+                                  const std::vector<OpReqType>& grad_req_types,
+                                  const std::unordered_set<std::string>& shared_arg_names,
+                                  const Executor* shared_exec,
+                                  std::unordered_map<std::string, NDArray>* shared_buffer,
+                                  std::vector<NDArray>* in_arg_vec,
+                                  std::vector<NDArray>* arg_grad_vec,
+                                  std::vector<NDArray>* aux_state_vec) {
   // initialize in_args, arg_grads, and aux_states and populate grad_store_
   data_entry_.resize(idx.num_node_entries());
   size_t arg_top = 0, aux_top = 0;
@@ -863,78 +831,67 @@ void GraphExecutor::InitArguments(
     const uint32_t eid = idx.entry_id(nid, 0);
     const TShape& inferred_shape = inferred_shapes[eid];
     const int inferred_dtype = inferred_dtypes[eid];
-    const NDArrayStorageType inferred_stype =
-        (NDArrayStorageType)inferred_stypes[eid];
+    const NDArrayStorageType inferred_stype = (NDArrayStorageType) inferred_stypes[eid];
     const std::string& arg_name = idx[nid].source->attrs.name;
     // aux_states
     if (mutable_nodes.count(nid)) {
       if (nullptr != shared_exec) {
         const NDArray& aux_nd = shared_exec->aux_state_map().at(arg_name);
-        CHECK(inferred_stype == kDefaultStorage &&
-              aux_nd.storage_type() == kDefaultStorage)
-            << "Non-default storage type detected when creating auxilliary "
-               "NDArray. The allocated "
-            << "memory of shared_exec.aux_array cannot be resued for argument: "
-            << arg_name << " for the current executor";
+        CHECK(inferred_stype == kDefaultStorage && aux_nd.storage_type() == kDefaultStorage)
+          << "Non-default storage type detected when creating auxilliary NDArray. The allocated "
+          << "memory of shared_exec.aux_array cannot be resued for argument: "
+          << arg_name << " for the current executor";
         CHECK_EQ(inferred_shape, aux_nd.shape())
-            << "Inferred shape does not match shared_exec.aux_array's shape."
-               " Therefore, the allocated memory for shared_exec.aux_array "
-               "cannot"
-               " be resued for creating auxilliary NDArray of the argument: "
-            << arg_name << " for the current executor";
+          << "Inferred shape does not match shared_exec.aux_array's shape."
+             " Therefore, the allocated memory for shared_exec.aux_array cannot"
+             " be resued for creating auxilliary NDArray of the argument: "
+          << arg_name << " for the current executor";
         CHECK_EQ(inferred_dtype, aux_nd.dtype())
-            << "Inferred dtype does not match shared_exec.aux_array's dtype."
-               " Therefore, the allocated memory for shared_exec.aux_array "
-               "cannot"
-               " be resued for creating auxilliary NDArray of the argument: "
-            << arg_name << " for the current executor";
+          << "Inferred dtype does not match shared_exec.aux_array's dtype."
+             " Therefore, the allocated memory for shared_exec.aux_array cannot"
+             " be resued for creating auxilliary NDArray of the argument: "
+          << arg_name << " for the current executor";
         aux_state_vec->emplace_back(aux_nd);
       } else {
-        EmplaceBackZeros(inferred_stype, inferred_shape,
-                         aux_state_ctxes[aux_top], inferred_dtype,
-                         aux_state_vec);
+        EmplaceBackZeros(inferred_stype, inferred_shape, aux_state_ctxes[aux_top],
+                         inferred_dtype, aux_state_vec);
       }  // if (has_shared_exec)
       data_entry_[eid] = aux_state_vec->back();
       aux_state_map_.emplace(arg_name, aux_state_vec->back());
       ++aux_top;
-    } else {                                   // in_args and grad for in_args
+    } else {  // in_args and grad for in_args
       if (shared_arg_names.count(arg_name)) {  // model parameter
         // model parameter
         if (nullptr != shared_exec) {
           const NDArray& in_arg_nd = shared_exec->in_arg_map().at(arg_name);
           auto arg_nd_stype = in_arg_nd.storage_type();
-          // for model parameter, both default storage and row_sparse storage
-          // can be shared
+          // for model parameter, both default storage and row_sparse storage can be shared
           bool shareable_arg_stype = inferred_stype == kDefaultStorage ||
                                      inferred_stype == kRowSparseStorage;
           // try to reuse memory from shared_exec
-          CHECK(shareable_arg_stype)
-              << "Inferred storage type "
-              << common::stype_string(inferred_stype)
-              << " does not support memory sharing with shared_exec.arg_array";
+          CHECK(shareable_arg_stype) << "Inferred storage type "
+            << common::stype_string(inferred_stype)
+            << " does not support memory sharing with shared_exec.arg_array";
           CHECK_EQ(inferred_stype, arg_nd_stype)
-              << "Inferred stype does not match shared_exec.arg_array's stype"
-                 " Therefore, the allocated memory for shared_exec.arg_array "
-                 "cannot"
-                 " be resued for creating NDArray of the argument"
-              << arg_name << " for the current executor";
+            << "Inferred stype does not match shared_exec.arg_array's stype"
+               " Therefore, the allocated memory for shared_exec.arg_array cannot"
+               " be resued for creating NDArray of the argument"
+            << arg_name << " for the current executor";
           CHECK_EQ(inferred_shape, in_arg_nd.shape())
-              << "Inferred shape does not match shared_exec.arg_array's shape"
-                 " Therefore, the allocated memory for shared_exec.arg_array "
-                 "cannot"
-                 " be resued for creating NDArray of the argument"
-              << arg_name << " for the current executor";
+            << "Inferred shape does not match shared_exec.arg_array's shape"
+               " Therefore, the allocated memory for shared_exec.arg_array cannot"
+               " be resued for creating NDArray of the argument"
+            << arg_name << " for the current executor";
           CHECK_EQ(inferred_dtype, in_arg_nd.dtype())
-              << "Inferred dtype does not match shared_exec.arg_array's dtype"
-                 " Therefore, the allocated memory for shared_exec.arg_array "
-                 "cannot"
-                 " be resued for creating NDArray of the argument"
-              << arg_name << " for the current executor";
+            << "Inferred dtype does not match shared_exec.arg_array's dtype"
+               " Therefore, the allocated memory for shared_exec.arg_array cannot"
+               " be resued for creating NDArray of the argument"
+            << arg_name << " for the current executor";
           in_arg_vec->emplace_back(in_arg_nd);
         } else {
           // doesn't have shared_exec, or non-default storage
-          EmplaceBackZeros(inferred_stype, inferred_shape,
-                           in_arg_ctxes[arg_top], inferred_dtype, in_arg_vec);
+          EmplaceBackZeros(inferred_stype, inferred_shape, in_arg_ctxes[arg_top],
+                           inferred_dtype, in_arg_vec);
         }
         // gradient for model parameter
         if (kNullOp == grad_req_types[arg_top]) {
@@ -942,45 +899,39 @@ void GraphExecutor::InitArguments(
         } else {
           auto grad_oid = grad_store_.size() + num_forward_outputs_;
           auto grad_eid = idx.entry_id(idx.outputs()[grad_oid]);
-          auto grad_stype = (NDArrayStorageType)inferred_stypes[grad_eid];
+          auto grad_stype = (NDArrayStorageType) inferred_stypes[grad_eid];
           if (nullptr != shared_exec && grad_stype == kDefaultStorage &&
-              shared_exec->arg_grad_map().at(arg_name).storage_type() ==
-                  kDefaultStorage) {
+              shared_exec->arg_grad_map().at(arg_name).storage_type() == kDefaultStorage) {
             // try to reuse memory from shared_exec
-            arg_grad_vec->emplace_back(
-                shared_exec->arg_grad_map().at(arg_name));
+            arg_grad_vec->emplace_back(shared_exec->arg_grad_map().at(arg_name));
           } else {
-            // no need to reuse memory from shared_exec for gradient of
-            // non-default storage
-            EmplaceBackZeros(grad_stype, inferred_shape,
-                             arg_grad_ctxes[arg_top], inferred_dtype,
-                             arg_grad_vec);
+            // no need to reuse memory from shared_exec for gradient of non-default storage
+            EmplaceBackZeros(grad_stype, inferred_shape, arg_grad_ctxes[arg_top],
+                             inferred_dtype, arg_grad_vec);
           }
-          grad_store_.emplace_back(grad_req_types[arg_top],
-                                   arg_grad_vec->back());
+          grad_store_.emplace_back(grad_req_types[arg_top], arg_grad_vec->back());
         }
       } else {  // !shared_arg_names.count(arg_name)
         // model parameter, row_sparse ndarray sharing enabled
         bool enable_row_sparse_sharing = true;
-        in_arg_vec->emplace_back(ReshapeOrCreate(
-            arg_name, inferred_shape, inferred_dtype, inferred_stype,
-            in_arg_ctxes[arg_top], shared_buffer, enable_row_sparse_sharing));
+        in_arg_vec->emplace_back(ReshapeOrCreate(arg_name, inferred_shape, inferred_dtype,
+                                                 inferred_stype, in_arg_ctxes[arg_top],
+                                                 shared_buffer, enable_row_sparse_sharing));
         // gradient for model parameter, row_sparse ndarray sharing disabled
         if (kNullOp == grad_req_types[arg_top]) {
           arg_grad_vec->emplace_back();
         } else {
           auto grad_oid = grad_store_.size() + num_forward_outputs_;
           auto grad_eid = idx.entry_id(idx.outputs()[grad_oid]);
-          auto grad_stype = (NDArrayStorageType)inferred_stypes[grad_eid];
+          auto grad_stype = (NDArrayStorageType) inferred_stypes[grad_eid];
           bool enable_row_sparse_sharing = false;
-          arg_grad_vec->emplace_back(ReshapeOrCreate(
-              "grad of " + arg_name, inferred_shape, inferred_dtype, grad_stype,
-              arg_grad_ctxes[arg_top], shared_buffer,
-              enable_row_sparse_sharing));
-          grad_store_.emplace_back(grad_req_types[arg_top],
-                                   arg_grad_vec->back());
+          arg_grad_vec->emplace_back(ReshapeOrCreate("grad of " + arg_name, inferred_shape,
+                                                     inferred_dtype, grad_stype,
+                                                     arg_grad_ctxes[arg_top], shared_buffer,
+                                                     enable_row_sparse_sharing));
+          grad_store_.emplace_back(grad_req_types[arg_top], arg_grad_vec->back());
         }  // if (kNullOp == grad_req_types[arg_top])
-      }    // if (shared_arg_names.count(arg_name))
+      }  // if (shared_arg_names.count(arg_name))
       in_arg_map_.emplace(arg_name, in_arg_vec->back());
       if (!arg_grad_vec->back().is_none()) {
         arg_grad_map_.emplace(arg_name, arg_grad_vec->back());
@@ -995,16 +946,16 @@ void GraphExecutor::InitArguments(
  * \brief Finish graph initialization after shape and dtype inferences.
  * This function is used by both simple_bind and bind flows.
  */
-void GraphExecutor::FinishInitGraph(
-    nnvm::Symbol symbol, nnvm::Graph g, Executor* shared_exec,
-    const nnvm::NodeEntryMap<NDArray>& feed_dict) {
+void GraphExecutor::FinishInitGraph(nnvm::Symbol symbol,
+                                    nnvm::Graph g,
+                                    Executor* shared_exec,
+                                    const nnvm::NodeEntryMap<NDArray>& feed_dict) {
   const auto& idx = g.indexed_graph();
   const auto& vstorage_type = g.GetAttr<StorageTypeVector>("storage_type");
 
   // data entries for output gradients
   for (size_t j = num_forward_outputs_; j < idx.outputs().size(); ++j) {
-    data_entry_[idx.entry_id(idx.outputs()[j])] =
-        grad_store_[j - num_forward_outputs_].second;
+    data_entry_[idx.entry_id(idx.outputs()[j])] = grad_store_[j - num_forward_outputs_].second;
   }
 
   {
@@ -1019,23 +970,20 @@ void GraphExecutor::FinishInitGraph(
       arg_storage_id[eid] = kExternalStorageID;
     }
     for (size_t i = 0; i < idx.num_node_entries(); i++) {
-      if (vstorage_type[i] != kDefaultStorage)
-        arg_storage_id[i] = kDynamicStorageID;
+      if (vstorage_type[i] != kDefaultStorage) arg_storage_id[i] = kDynamicStorageID;
     }
     g.attrs["storage"] = std::make_shared<dmlc::any>(std::move(arg_storage_id));
     g = nnvm::ApplyPass(g, "PlanMemory");
   }
   g = DetectInplaceAddTo(g);
 
-  g.attrs["saved_states"] =
-      std::make_shared<nnvm::any>(std::move(saved_states_));
+  g.attrs["saved_states"] = std::make_shared<nnvm::any>(std::move(saved_states_));
   g = AttachOpExecs(g);
   g = AttachOpResources(g);
   graph_ = std::move(g);
 
   if (shared_exec != nullptr) {
-    this->InitDataEntryMemory(
-        &(dynamic_cast<GraphExecutor*>(shared_exec)->data_pool_));
+    this->InitDataEntryMemory(&(dynamic_cast<GraphExecutor*>(shared_exec)->data_pool_));
   } else {
     this->InitDataEntryMemory(nullptr);
   }
@@ -1073,23 +1021,25 @@ void GraphExecutor::FinishInitGraph(
  * NDArrays for in_args, arg_grads, and aux_states for resuing
  * already allocated memory.
  */
-void GraphExecutor::Init(
-    nnvm::Symbol symbol, const Context& default_ctx,
-    const std::map<std::string, Context>& ctx_map,
-    const std::vector<Context>& in_arg_ctxes,
-    const std::vector<Context>& arg_grad_ctxes,
-    const std::vector<Context>& aux_state_ctxes,
-    const std::unordered_map<std::string, TShape>& arg_shape_mapRef,
-    const std::unordered_map<std::string, int>& arg_dtype_mapRef,
-    const std::unordered_map<std::string, int>& arg_stype_map,
-    const std::vector<OpReqType>& grad_req_types,
-    const std::unordered_set<std::string>& shared_arg_names,
-    std::vector<NDArray>* in_arg_vec, std::vector<NDArray>* arg_grad_vec,
-    std::vector<NDArray>* aux_state_vec,
-    std::unordered_map<std::string, NDArray>* shared_buffer,
-    Executor* shared_exec, const nnvm::NodeEntryMap<NDArray>& feed_dict) {
-  nnvm::Graph g = InitGraph(symbol, default_ctx, ctx_map, in_arg_ctxes,
-                            arg_grad_ctxes, aux_state_ctxes, grad_req_types);
+void GraphExecutor::Init(nnvm::Symbol symbol,
+                         const Context& default_ctx,
+                         const std::map<std::string, Context>& ctx_map,
+                         const std::vector<Context>& in_arg_ctxes,
+                         const std::vector<Context>& arg_grad_ctxes,
+                         const std::vector<Context>& aux_state_ctxes,
+                         const std::unordered_map<std::string, TShape>& arg_shape_mapRef,
+                         const std::unordered_map<std::string, int>& arg_dtype_mapRef,
+                         const std::unordered_map<std::string, int>& arg_stype_map,
+                         const std::vector<OpReqType>& grad_req_types,
+                         const std::unordered_set<std::string>& shared_arg_names,
+                         std::vector<NDArray>* in_arg_vec,
+                         std::vector<NDArray>* arg_grad_vec,
+                         std::vector<NDArray>* aux_state_vec,
+                         std::unordered_map<std::string, NDArray>* shared_buffer,
+                         Executor* shared_exec,
+                         const nnvm::NodeEntryMap<NDArray>& feed_dict) {
+  nnvm::Graph g = InitGraph(symbol, default_ctx, ctx_map, in_arg_ctxes, arg_grad_ctxes,
+                            aux_state_ctxes, grad_req_types);
 
   // make copies so that ngraph compilation can modify shape / dtype
   std::unordered_map<std::string, TShape> arg_shape_map = arg_shape_mapRef;
@@ -1100,7 +1050,7 @@ void GraphExecutor::Init(
   // TODO(mbrookhart): Remove this when hetr can handle multiple contexts
   auto multi_context = multi_context_check(default_ctx, in_arg_ctxes,
                                            arg_grad_ctxes, aux_state_ctxes);
-  auto grad_sparse = grad_sparse_check(*arg_grad_vec);
+  const auto grad_sparse = grad_sparse_check(*arg_grad_vec);
   ngraph_bridge::SimpleBindArg simplebind(num_forward_inputs_, arg_shape_map,
                                           arg_dtype_map, arg_stype_mapn);
   ngraph_bridge::Compiler compiler(
@@ -1118,12 +1068,11 @@ void GraphExecutor::Init(
     // create "device" and "context" attrs for the graph
     g = InitFullGraph(g, compiler.GetInputs(), grad_req_types);
   } else {
-    g = InitFullGraph(g, symbol.ListInputs(nnvm::Symbol::kReadOnlyArgs),
-                      grad_req_types);
+    g = InitFullGraph(g, symbol.ListInputs(nnvm::Symbol::kReadOnlyArgs), grad_req_types);
   }
-  g = AssignContext(g, default_ctx, ctx_map, in_arg_ctxes, arg_grad_ctxes,
-                    aux_state_ctxes, grad_req_types, num_forward_inputs_,
-                    num_forward_outputs_);
+    g = AssignContext(g, default_ctx, ctx_map, in_arg_ctxes, arg_grad_ctxes,
+                      aux_state_ctxes, grad_req_types, num_forward_inputs_,
+                      num_forward_outputs_);
 #endif
 
   // The following code of shape and dtype inferences and argument
@@ -1131,8 +1080,7 @@ void GraphExecutor::Init(
   // should do this differently.
 
   // Initialize arg_shapes and arg_dtypes for shape and type inferences.
-  // It contains all in_args and aux_states' shapes and types in a certain
-  // order.
+  // It contains all in_args and aux_states' shapes and types in a certain order.
   const nnvm::IndexedGraph& idx = g.indexed_graph();
 
 #if MXNET_USE_NGRAPH == 1
@@ -1185,24 +1133,24 @@ void GraphExecutor::Init(
   if (nullptr == shared_buffer) {  // regular simple bind
     InitArguments(idx, g.GetAttr<nnvm::ShapeVector>("shape"),
                   g.GetAttr<nnvm::DTypeVector>("dtype"),
-                  g.GetAttr<StorageTypeVector>("storage_type"), in_arg_ctxes,
-                  arg_grad_ctxes, aux_state_ctxes, grad_req_types, in_arg_vec,
-                  arg_grad_vec, aux_state_vec);
+                  g.GetAttr<StorageTypeVector>("storage_type"),
+                  in_arg_ctxes, arg_grad_ctxes, aux_state_ctxes,
+                  grad_req_types, in_arg_vec, arg_grad_vec, aux_state_vec);
   } else {  // simple bind using shared data arrays and shared_exec
     InitArguments(idx, g.GetAttr<nnvm::ShapeVector>("shape"),
                   g.GetAttr<nnvm::DTypeVector>("dtype"),
-                  g.GetAttr<StorageTypeVector>("storage_type"), in_arg_ctxes,
-                  arg_grad_ctxes, aux_state_ctxes, grad_req_types,
-                  shared_arg_names, shared_exec, shared_buffer, in_arg_vec,
-                  arg_grad_vec, aux_state_vec);
+                  g.GetAttr<StorageTypeVector>("storage_type"),
+                  in_arg_ctxes, arg_grad_ctxes, aux_state_ctxes,
+                  grad_req_types, shared_arg_names, shared_exec,
+                  shared_buffer, in_arg_vec, arg_grad_vec, aux_state_vec);
   }
-// The above code of shape and dtype inferences and argument
-// initialization is for simple_bind only. Regular bind operation
-// should do this differently.
+  // The above code of shape and dtype inferences and argument
+  // initialization is for simple_bind only. Regular bind operation
+  // should do this differently.
 
-// Initialize the rest attributes of the graph.
-// This function can be called by regular bind
-// operation flow as well.
+  // Initialize the rest attributes of the graph.
+  // This function can be called by regular bind
+  // operation flow as well.
 #if MXNET_USE_NGRAPH == 1
   if (!multi_context && !grad_sparse) {
     FinishInitGraph(symbol, g, shared_exec, compiler.GetFeedDict());
@@ -1221,7 +1169,8 @@ void GraphExecutor::Init(
  * attributes in the graph, and calculate the number
  * of forward nodes.
  */
-Graph GraphExecutor::InitGraph(nnvm::Symbol symbol, const Context& default_ctx,
+Graph GraphExecutor::InitGraph(nnvm::Symbol symbol,
+                               const Context& default_ctx,
                                const std::map<std::string, Context>& ctx_map,
                                const std::vector<Context>& in_arg_ctxes,
                                const std::vector<Context>& arg_grad_ctxes,
@@ -1237,8 +1186,12 @@ Graph GraphExecutor::InitGraph(nnvm::Symbol symbol, const Context& default_ctx,
   g = InitFullGraph(g, symbol.ListInputs(nnvm::Symbol::kReadOnlyArgs),
                     grad_req_types);
   // create "device" and "context" attrs for the graph
-  g = AssignContext(g, default_ctx, ctx_map, in_arg_ctxes, arg_grad_ctxes,
-                    aux_state_ctxes, grad_req_types, num_forward_inputs_,
+  g = AssignContext(g, default_ctx, ctx_map,
+                    in_arg_ctxes,
+                    arg_grad_ctxes,
+                    aux_state_ctxes,
+                    grad_req_types,
+                    num_forward_inputs_,
                     num_forward_outputs_);
 
   const auto& idx = g.indexed_graph();
@@ -1270,14 +1223,13 @@ void GraphExecutor::InitDataEntryMemory(std::vector<NDArray>* shared_pool) {
   CHECK_EQ(idx.num_node_entries(), vstorage.size());
   CHECK_EQ(data_entry_.size(), vshape.size());
   std::vector<Context> data_context(idx.num_node_entries());
-  std::vector<NDArrayStorageType> data_storage_type(idx.num_node_entries(),
-                                                    kUndefinedStorage);
+  std::vector<NDArrayStorageType> data_storage_type(idx.num_node_entries(), kUndefinedStorage);
   for (uint32_t nid = 0; nid < idx.num_nodes(); ++nid) {
     for (uint32_t i = 0; i < idx[nid].source->num_outputs(); ++i) {
       auto eid = idx.entry_id(nid, i);
       data_context[eid] = vctx[nid];
       CHECK_NE(vstorage_type[nid], kUndefinedStorage);
-      data_storage_type[eid] = (NDArrayStorageType)vstorage_type[nid];
+      data_storage_type[eid] = (NDArrayStorageType) vstorage_type[nid];
     }
   }
 
@@ -1294,17 +1246,15 @@ void GraphExecutor::InitDataEntryMemory(std::vector<NDArray>* shared_pool) {
     uint32_t nid = idx.input_nodes().at(i);
     uint32_t oid = head_grad_map_.at(idx[nid].source);
     uint32_t eid = idx.entry_id(idx.outputs()[oid]);
-    NDArrayStorageType stype = (NDArrayStorageType)vstorage_type[eid];
+    NDArrayStorageType stype = (NDArrayStorageType) vstorage_type[eid];
     CHECK_NE(vshape[eid].ndim(), 0U);
     CHECK_NE(vdtype[eid], -1);
     auto data_eid = idx.entry_id(nid, 0);
     // initialize based on storage_type
     if (stype != kDefaultStorage) {
-      data_entry_[data_eid] =
-          NDArray(stype, vshape[eid], data_context[eid], true, vdtype[eid]);
+      data_entry_[data_eid] = NDArray(stype, vshape[eid], data_context[eid], true, vdtype[eid]);
     } else {
-      data_entry_[data_eid] =
-          NDArray(vshape[eid], data_context[eid], false, vdtype[eid]);
+      data_entry_[data_eid] = NDArray(vshape[eid], data_context[eid], false, vdtype[eid]);
     }
     if (log_verbose_) {
       LOG(INFO) << "\tinit head_grad entry\t" << data_eid << "\tas "
@@ -1316,13 +1266,11 @@ void GraphExecutor::InitDataEntryMemory(std::vector<NDArray>* shared_pool) {
     if (!data_entry_[i].is_none()) continue;
     size_t bytes = vshape[i].Size() * mshadow::mshadow_sizeof(vdtype[i]);
     int storage_id = vstorage[i];
-    // skip pool allocation for kBadStorageID, kExternalStorageID and
-    // kDynamicStorageID
+    // skip pool allocation for kBadStorageID, kExternalStorageID and kDynamicStorageID
     if (storage_id < 0) continue;
     size_t sid = static_cast<size_t>(storage_id);
     if (sid >= pool_info.size()) {
-      pool_info.resize(sid + 1,
-                       PoolEntry{Context::CPU(), size_t(0), kUndefinedStorage});
+      pool_info.resize(sid + 1, PoolEntry{Context::CPU(), size_t(0), kUndefinedStorage});
     }
     PoolEntry& info = pool_info[sid];
     if (info.bytes == 0) {
@@ -1348,11 +1296,10 @@ void GraphExecutor::InitDataEntryMemory(std::vector<NDArray>* shared_pool) {
   for (size_t i = 0; i < pool_info.size(); i++) {
     sorted_pool_index.push_back(i);
   }
-  auto pool_comparator = [&pool_info](int lhs, int rhs) {
+  auto pool_comparator = [&pool_info](int lhs, int rhs){
     return pool_info[lhs].bytes > pool_info[rhs].bytes;
   };
-  std::sort(sorted_pool_index.begin(), sorted_pool_index.end(),
-            pool_comparator);
+  std::sort(sorted_pool_index.begin(), sorted_pool_index.end(), pool_comparator);
 
   for (size_t i : sorted_pool_index) {
     const Context& ctx = pool_info[i].ctx;
@@ -1376,7 +1323,7 @@ void GraphExecutor::InitDataEntryMemory(std::vector<NDArray>* shared_pool) {
       NDArray nd(shape, ctx, true);
       data_pool_[i] = nd;
       // put the new allocated arrays to shared pool
-      if (shared_pool != nullptr) {
+      if (shared_pool != nullptr)  {
         shared_pool->push_back(nd);
       }
     }
@@ -1388,7 +1335,7 @@ void GraphExecutor::InitDataEntryMemory(std::vector<NDArray>* shared_pool) {
     if (!data_entry_[i].is_none()) continue;
     // assign allocated array by storage id
     int storage_id = vstorage[i];
-    auto storage_type = (NDArrayStorageType)vstorage_type[i];
+    auto storage_type = (NDArrayStorageType) vstorage_type[i];
     if (storage_type == kDefaultStorage) {
       CHECK_GE(storage_id, 0) << "Do not support runtime shape op yet";
       const NDArray& src = data_pool_.at(storage_id);
@@ -1397,22 +1344,22 @@ void GraphExecutor::InitDataEntryMemory(std::vector<NDArray>* shared_pool) {
       data_entry_[i] = NDArray(storage_type, vshape[i], data_context[i]);
     }
     if (log_verbose_) {
-      LOG(INFO) << "\tinit data entry\t" << i << "\tas "
-                << common::stype_string(storage_type);
+      LOG(INFO) << "\tinit data entry\t" << i << "\tas " << common::stype_string(storage_type);
     }
   }
 }
+
 
 void GraphExecutor::InitCachedOps() {
   // get the graph
   const auto& idx = graph_.indexed_graph();
   const auto& vstorage_inplace =
       graph_.GetAttr<std::vector<int> >("storage_inplace_index");
-  const auto& op_execs = graph_.GetAttr<OpExecVector>("op_execs");
+  const auto& op_execs =
+      graph_.GetAttr<OpExecVector>("op_execs");
   const auto& vctx = graph_.GetAttr<ContextVector>("context");
   const auto& addto_entry = graph_.GetAttr<std::vector<int> >("addto_entry");
-  const auto& skip_plus_node =
-      graph_.GetAttr<std::vector<int> >("skip_plus_node");
+  const auto& skip_plus_node = graph_.GetAttr<std::vector<int> >("skip_plus_node");
 
   op_nodes_.resize(idx.num_nodes());
   // setup the array and requirements.
@@ -1425,8 +1372,7 @@ void GraphExecutor::InitCachedOps() {
     op_nodes_[nid].opr_name = nullptr;
 #endif
     if (skip_plus_node.at(nid)) {
-      op_nodes_[nid].skip_exec_node = true;
-      continue;
+      op_nodes_[nid].skip_exec_node = true; continue;
     }
 
     op_nodes_[nid].exec = op_execs[nid];
@@ -1490,13 +1436,12 @@ void GraphExecutor::InitCachedOps() {
               std::inserter(all_vars, all_vars.end()));
     // setup exec vars
     Engine::Get()->PushAsync(
-        [exec](RunContext rctx, Engine::CallbackOnComplete on_complete) {
-          exec->Setup();
-          on_complete();
-        },
-        Context::CPU(), {}, all_vars, FnProperty::kNormal, 0,
-        PROFILER_MESSAGE("SetupExec"));
-    auto exec_fun = [exec, is_async, is_gpu](
+      [exec](RunContext rctx, Engine::CallbackOnComplete on_complete) {
+        exec->Setup();
+        on_complete();
+      }, Context::CPU(), {}, all_vars, FnProperty::kNormal, 0,
+      PROFILER_MESSAGE("SetupExec"));
+    auto exec_fun = [exec, is_async, is_gpu] (
         RunContext ctx, Engine::CallbackOnComplete on_complete) {
       if (is_async) {
         exec->op_ctx.async_on_complete = on_complete;
@@ -1505,12 +1450,12 @@ void GraphExecutor::InitCachedOps() {
       // call on complete only if it is async op
       if (!is_async) {
         if (is_gpu) {
-#if MXNET_USE_CUDA
+        #if MXNET_USE_CUDA
           // Wait GPU kernel to finish.
           ctx.get_stream<gpu>()->Wait();
-#else
+        #else
           LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
-#endif
+        #endif
         }
         on_complete();
       }
@@ -1532,14 +1477,13 @@ void GraphExecutor::InitOpSegs() {
   if (monitor_callback_) return;
 
   // Generate segments based on the graph structure
-  bool prefer_bulk_exec_inference =
-      dmlc::GetEnv("MXNET_EXEC_BULK_EXEC_INFERENCE", true);
+  bool prefer_bulk_exec_inference = dmlc::GetEnv("MXNET_EXEC_BULK_EXEC_INFERENCE", true);
   // Whether to perform bulk exec for training
   bool prefer_bulk_exec = dmlc::GetEnv("MXNET_EXEC_BULK_EXEC_TRAIN", 1);
 
   bool is_training = num_forward_nodes_ != total_num_nodes;
 
-  if (prefer_bulk_exec && is_training) {
+  if (prefer_bulk_exec  && is_training) {
     this->BulkTrainingOpSegs(total_num_nodes);
   }
 
@@ -1552,53 +1496,48 @@ void GraphExecutor::InitOpSegs() {
 
 void GraphExecutor::BulkTrainingOpSegs(size_t total_num_nodes) {
   // The maximum number of node in a segment executed in bulk
-  size_t num_nodes_threshold =
-      dmlc::GetEnv("MXNET_EXEC_BULK_EXEC_MAX_NODE_TRAIN", 15);
+  size_t num_nodes_threshold = dmlc::GetEnv("MXNET_EXEC_BULK_EXEC_MAX_NODE_TRAIN", 15);
 
   // create forward segments for training
   size_t topo_start = 0;
   for (size_t nid = 0; nid < num_forward_nodes_; nid++) {
-    auto& node = graph_.indexed_graph()[nid].source;
-    auto& op_node = op_nodes_[nid];
-    // check if the segment relies on external input, or exceeds maxinum number
-    // of node,
+    auto &node = graph_.indexed_graph()[nid].source;
+    auto &op_node = op_nodes_[nid];
+    // check if the segment relies on external input, or exceeds maxinum number of node,
     // or requires async ops
     if (node->is_variable() || nid - topo_start > num_nodes_threshold ||
         op_node.exec->exec_type() != ExecType::kSync) {
-      // create a new segment for the previous nodes if the current one cannot
-      // be bulked
+      // create a new segment for the previous nodes if the current one cannot be bulked
       cached_seg_opr_[topo_start] = this->CreateCachedSegOpr(topo_start, nid);
       topo_start = nid + 1;
     }
   }
   // the last segment
   if (topo_start != num_forward_nodes_) {
-    cached_seg_opr_[topo_start] =
-        this->CreateCachedSegOpr(topo_start, num_forward_nodes_);
+    cached_seg_opr_[topo_start] = this->CreateCachedSegOpr(topo_start, num_forward_nodes_);
   }
 
   // create backward segments for training
   // get all gradient variables
   std::unordered_set<engine::VarHandle> grad_vars;
-  for (auto& kv : grad_store_) {
+  for (auto &kv : grad_store_) {
     grad_vars.insert(kv.second.var());
   }
-  auto& idx = graph_.indexed_graph();
+  auto &idx = graph_.indexed_graph();
   topo_start = num_forward_nodes_;
   for (size_t nid = num_forward_nodes_; nid < total_num_nodes; nid++) {
-    auto& op_node = op_nodes_[nid];
+    auto &op_node = op_nodes_[nid];
     if (op_node.skip_exec_node || op_node.exec == nullptr) {
       continue;
     }
-    if (idx[nid].source->is_variable() ||
-        nid - topo_start > num_nodes_threshold ||
+    if (idx[nid].source->is_variable() || nid - topo_start > num_nodes_threshold ||
         op_node.exec->exec_type() != ExecType::kSync) {
       cached_seg_opr_[topo_start] = this->CreateCachedSegOpr(topo_start, nid);
       topo_start = nid + 1;
     } else {
       // If it produces output gradient, don't include it in the segment
       bool output_gradient = false;
-      for (auto& out_arr : op_node.exec->out_array) {
+      for (auto &out_arr : op_node.exec->out_array) {
         if (grad_vars.find(out_arr.var()) != grad_vars.end()) {
           output_gradient = true;
         }
@@ -1611,19 +1550,17 @@ void GraphExecutor::BulkTrainingOpSegs(size_t total_num_nodes) {
   }
   // last segment for backward
   if (topo_start < total_num_nodes) {
-    cached_seg_opr_[topo_start] =
-        this->CreateCachedSegOpr(topo_start, total_num_nodes);
+    cached_seg_opr_[topo_start] = this->CreateCachedSegOpr(topo_start, total_num_nodes);
   }
 }
 
 void GraphExecutor::BulkInferenceOpSegs() {
-  // Attempt to bulk the whole graph for inference.  We will only create new
-  // segments when
+  // Attempt to bulk the whole graph for inference.  We will only create new segments when
   // required for non-kSync operations.
   size_t topo_start = 0;
   for (size_t nid = 0; nid < num_forward_nodes_; nid++) {
-    auto& node = graph_.indexed_graph()[nid].source;
-    auto& op_node = op_nodes_[nid];
+    auto &node = graph_.indexed_graph()[nid].source;
+    auto &op_node = op_nodes_[nid];
 
     // Variables do not need to be segmented at inference time.
     if (node->is_variable()) continue;
@@ -1635,8 +1572,7 @@ void GraphExecutor::BulkInferenceOpSegs() {
   }
   // The last segment
   if (topo_start != num_forward_nodes_) {
-    cached_seg_opr_[topo_start] =
-        this->CreateCachedSegOpr(topo_start, num_forward_nodes_);
+    cached_seg_opr_[topo_start] = this->CreateCachedSegOpr(topo_start, num_forward_nodes_);
   }
 }
 
@@ -1656,7 +1592,7 @@ void GraphExecutor::ExecuteMonCallback(size_t nid) {
     }
   }
   for (index_t i = 0; i < opnode.exec->out_array.size(); ++i) {
-    NDArray* cpy = new NDArray(opnode.exec->out_array[i]);
+    NDArray *cpy = new NDArray(opnode.exec->out_array[i]);
     std::string name = inode.source->attrs.name + "_" + output_names[i];
     this->monitor_callback_(name.c_str(), reinterpret_cast<void*>(cpy));
   }
@@ -1677,11 +1613,9 @@ void GraphExecutor::RunOps(bool is_train, size_t topo_start, size_t topo_end) {
   for (size_t nid = topo_start; nid < topo_end; ++nid) {
     auto seg_op = cached_seg_opr_[nid];
     // Check segments first
-    if (monitor_callback_ == nullptr && seg_op.opr != nullptr &&
-        seg_op.topo_end <= topo_end) {
+    if (monitor_callback_ == nullptr && seg_op.opr != nullptr && seg_op.topo_end <= topo_end) {
 #if MXNET_USE_PROFILER
-      bool profiling =
-          engine::Profiler::Get()->GetState() == engine::Profiler::kRunning;
+      bool profiling = engine::Profiler::Get()->GetState() == engine::Profiler::kRunning;
 #else
       bool profiling = false;
 #endif
@@ -1702,8 +1636,7 @@ void GraphExecutor::RunOps(bool is_train, size_t topo_start, size_t topo_end) {
       CopyFromTo(opnode.exec->in_array[0], &(opnode.exec->out_array[0]));
     } else if (opnode.cached_opr != nullptr) {
 #if MXNET_USE_PROFILER
-      bool profiling =
-          engine::Profiler::Get()->GetState() == engine::Profiler::kRunning;
+      bool profiling = engine::Profiler::Get()->GetState() == engine::Profiler::kRunning;
 #else
       bool profiling = false;
 #endif
@@ -1718,11 +1651,10 @@ void GraphExecutor::RunOps(bool is_train, size_t topo_start, size_t topo_end) {
   }
 }
 
-GraphExecutor::CachedSegOpr GraphExecutor::CreateCachedSegOpr(size_t topo_start,
-                                                              size_t topo_end) {
+GraphExecutor::CachedSegOpr GraphExecutor::CreateCachedSegOpr(size_t topo_start, size_t topo_end) {
   std::vector<Engine::VarHandle> use_vars;
   std::vector<Engine::VarHandle> mutate_vars;
-  Context* pctx = nullptr;
+  Context *pctx = nullptr;
   GraphExecutor::CachedSegOpr ret;
   ret.topo_start = topo_start;
   ret.topo_end = topo_end;
@@ -1767,10 +1699,10 @@ GraphExecutor::CachedSegOpr GraphExecutor::CreateCachedSegOpr(size_t topo_start,
   Engine::Get()->DeduplicateVarHandle(&use_vars, &mutate_vars);
 
   bool is_gpu = pctx->dev_mask() == gpu::kDevMask;
-  auto exec_fun = [exec_list, is_gpu](RunContext ctx,
-                                      Engine::CallbackOnComplete on_complete) {
+  auto exec_fun = [exec_list, is_gpu] (
+      RunContext ctx, Engine::CallbackOnComplete on_complete) {
     // Run all opr in the sub-graph
-    for (auto& exec : exec_list) {
+    for (auto &exec : exec_list) {
       exec->Run(ctx, is_gpu);
     }
     if (is_gpu) {
@@ -1784,53 +1716,57 @@ GraphExecutor::CachedSegOpr GraphExecutor::CreateCachedSegOpr(size_t topo_start,
     on_complete();
   };
 #if MXNET_USE_PROFILER
-  opr_names.pop_back();
-  opr_names += "]";
-  // the lifetime of `opr_names.c_str()` is same with opr_names
-  // you need to copy it out. (potential memory leak risk)
-  char* p_opr_name = new char[opr_names.size() + 1];
-  memcpy(p_opr_name, opr_names.c_str(), opr_names.size() + 1);
+    opr_names.pop_back();
+    opr_names += "]";
+    // the lifetime of `opr_names.c_str()` is same with opr_names
+    // you need to copy it out. (potential memory leak risk)
+    char *p_opr_name = new char[opr_names.size() + 1];
+    memcpy(p_opr_name, opr_names.c_str(), opr_names.size() + 1);
 #endif
-  ret.opr = Engine::Get()->NewOperator(exec_fun, use_vars, mutate_vars,
-                                       FnProperty::kNormal,
-                                       PROFILER_MESSAGE(p_opr_name));
+  ret.opr = Engine::Get()->NewOperator(
+      exec_fun, use_vars, mutate_vars, FnProperty::kNormal,
+      PROFILER_MESSAGE(p_opr_name));
   return ret;
 }
 }  // namespace exec
 
-Executor* Executor::SimpleBind(
-    nnvm::Symbol symbol, const Context& default_ctx,
-    const std::map<std::string, Context>& group2ctx,
-    const std::vector<Context>& in_arg_ctxes,
-    const std::vector<Context>& arg_grad_ctxes,
-    const std::vector<Context>& aux_state_ctxes,
-    const std::unordered_map<std::string, TShape>& arg_shape_map,
-    const std::unordered_map<std::string, int>& arg_dtype_map,
-    const std::unordered_map<std::string, int>& arg_stype_map,
-    const std::vector<OpReqType>& grad_req_types,
-    const std::unordered_set<std::string>& shared_arg_names,
-    std::vector<NDArray>* in_args, std::vector<NDArray>* arg_grads,
-    std::vector<NDArray>* aux_states,
-    std::unordered_map<std::string, NDArray>* shared_buffer,
-    Executor* shared_exec) {
+Executor *Executor::SimpleBind(nnvm::Symbol symbol,
+                               const Context& default_ctx,
+                               const std::map<std::string, Context>& group2ctx,
+                               const std::vector<Context>& in_arg_ctxes,
+                               const std::vector<Context>& arg_grad_ctxes,
+                               const std::vector<Context>& aux_state_ctxes,
+                               const std::unordered_map<std::string, TShape>& arg_shape_map,
+                               const std::unordered_map<std::string, int>& arg_dtype_map,
+                               const std::unordered_map<std::string, int>& arg_stype_map,
+                               const std::vector<OpReqType>& grad_req_types,
+                               const std::unordered_set<std::string>& shared_arg_names,
+                               std::vector<NDArray>* in_args,
+                               std::vector<NDArray>* arg_grads,
+                               std::vector<NDArray>* aux_states,
+                               std::unordered_map<std::string, NDArray>* shared_buffer,
+                               Executor* shared_exec) {
   auto exec = new exec::GraphExecutor();
-  exec->Init(symbol, default_ctx, group2ctx, in_arg_ctxes, arg_grad_ctxes,
-             aux_state_ctxes, arg_shape_map, arg_dtype_map, arg_stype_map,
-             grad_req_types, shared_arg_names, in_args, arg_grads, aux_states,
+  exec->Init(symbol, default_ctx, group2ctx,
+             in_arg_ctxes, arg_grad_ctxes, aux_state_ctxes,
+             arg_shape_map, arg_dtype_map, arg_stype_map,
+             grad_req_types, shared_arg_names,
+             in_args, arg_grads, aux_states,
              shared_buffer, shared_exec);
   return exec;
 }
 
-Executor* Executor::Bind(nnvm::Symbol symbol, const Context& default_ctx,
+Executor *Executor::Bind(nnvm::Symbol symbol,
+                         const Context& default_ctx,
                          const std::map<std::string, Context>& group2ctx,
-                         const std::vector<NDArray>& in_args,
-                         const std::vector<NDArray>& arg_grad_store,
-                         const std::vector<OpReqType>& grad_req_type,
-                         const std::vector<NDArray>& aux_states,
+                         const std::vector<NDArray> &in_args,
+                         const std::vector<NDArray> &arg_grad_store,
+                         const std::vector<OpReqType> &grad_req_type,
+                         const std::vector<NDArray> &aux_states,
                          Executor* shared_exec) {
   auto exec = new exec::GraphExecutor();
-  exec->Init(symbol, default_ctx, group2ctx, in_args, arg_grad_store,
-             grad_req_type, aux_states,
+  exec->Init(symbol, default_ctx, group2ctx,
+             in_args, arg_grad_store, grad_req_type, aux_states,
              reinterpret_cast<Executor*>(shared_exec));
   return exec;
 }

--- a/src/ngraph/ngraph_compiler.cc
+++ b/src/ngraph/ngraph_compiler.cc
@@ -92,10 +92,12 @@ void Compiler::Infer(const BindArg* bind) {
     if (mutable_nodes.count(nid)) {
       shapes_.push_back(bind->aux_states_[aux_top].shape());
       dtypes_.push_back(bind->aux_states_[aux_top].dtype());
+      stypes_.push_back(bind->aux_states_[aux_top].storage_type());
       ++aux_top;
     } else {
       shapes_.push_back(bind->in_args_[arg_top].shape());
       dtypes_.push_back(bind->in_args_[arg_top].dtype());
+      stypes_.push_back(bind->in_args_[arg_top].storage_type());
       ++arg_top;
     }
   }
@@ -103,6 +105,9 @@ void Compiler::Infer(const BindArg* bind) {
   // append default shapes / dtypes so that vector size = graph size
   shapes_.resize(idx.input_nodes().size(), nnvm::TShape());
   dtypes_.resize(idx.input_nodes().size(), -1);
+  /* std::cout << "stype resize: " << stypes_.size(); */
+  stypes_.resize(idx.input_nodes().size(), mxnet::kDefaultStorage);
+  /* std::cout << ":"<<stypes_.size() <<std::endl; */
 }
 
 // infer nnvm::Graph shape and dtype for simple bind case
@@ -111,6 +116,7 @@ void Compiler::Infer(const SimpleBindArg* simplebind) {
   const auto& idx = graph_.indexed_graph();
   shapes_.resize(idx.input_nodes().size(), nnvm::TShape());
   dtypes_.resize(idx.input_nodes().size(), -1);
+  stypes_.resize(idx.input_nodes().size(), -1);
   size_t arg_top = 0, aux_top = 0;
   for (size_t i = 0; i < simplebind->kNumForwardInputs; ++i) {
     const uint32_t nid = idx.input_nodes().at(i);
@@ -122,6 +128,10 @@ void Compiler::Infer(const SimpleBindArg* simplebind) {
     auto it2 = simplebind->dtype_map_.find(name);
     if (simplebind->dtype_map_.end() != it2) {
       dtypes_[i] = it2->second;
+    }
+    auto it3 = simplebind->stype_map_.find(name);
+    if (simplebind->stype_map_.end() != it3) {
+      stypes_[i] = it3->second;
     }
   }
 }
@@ -136,7 +146,8 @@ Compiler::Compiler(const nnvm::Graph& graph, const NDArrayMap& feed_dict,
                    const mxnet::Context& context)
     : ngraph_("ngraph_" + randomString(6), context) {
   DeepCopy(graph);
-
+  graph_.attrs["context"] = std::make_shared<nnvm::any>(
+      mxnet::exec::ContextVector(graph_.indexed_graph().num_nodes(), context));
   // infer nnvm::Graph shape and type
   auto bind = dynamic_cast<const BindArg*>(&bindbase);
   auto simplebind = dynamic_cast<const SimpleBindArg*>(&bindbase);
@@ -166,6 +177,8 @@ void Compiler::ProcessGraph(const NDArrayMap& feed_dict) {
   //    g.GetAttr<nnvm::DTypeVector>("dtype"));
   //}
 
+  graph_ = mxnet::exec::InferStorageType(std::move(graph_), std::move(stypes_),
+                                         "__storage_type__");
   MakeCopiedFeedDict(feed_dict);
   ParseNnvmGraph();
   CheckInNgraph();
@@ -201,6 +214,7 @@ nnvm::Graph Compiler::Compile() {
     if (node->type_ == NodeType::kAux || node->type_ == NodeType::kVariable) {
       ngraph_shape_[node->name_] = node->shape_;
       ngraph_dtype_[node->name_] = node->dtype_;
+      ngraph_stype_[node->name_] = node->stype_;
     }
   }
 
@@ -316,11 +330,13 @@ void Compiler::CheckInNgraph() {
             node->in_ngraph_ = false;
           }
         }
-        if (node->dtype_ == mshadow::kFloat16) {
+        if (node->dtype_ == mshadow::kFloat16 ||
+            node->stype_ != mxnet::kDefaultStorage) {
           node->in_ngraph_ = false;
         } else {
           for (auto input : node->inputs_) {
-            if (input->dtype_ == mshadow::kFloat16) {
+            if (input->dtype_ == mshadow::kFloat16 ||
+                input->stype_ != mxnet::kDefaultStorage) {
               node->in_ngraph_ = false;
             }
           }
@@ -394,11 +410,14 @@ void Compiler::ParseNnvmGraph() {
   const auto inferred_shapes =
       graph_.GetAttr<std::vector<nnvm::TShape>>("shape");
   const auto inferred_dtypes = graph_.GetAttr<std::vector<int>>("dtype");
+  const auto& inferred_stypes =
+      graph_.GetAttr<mxnet::StorageTypeVector>("storage_type");
   for (auto node : this->ngraph_.nodes_) {
     const uint32_t nid = idx.node_id(node->orig_node_.get());
     const uint32_t eid = idx.entry_id(nid, 0);
     node->shape_ = inferred_shapes[eid];
     node->dtype_ = inferred_dtypes[eid];
+    node->stype_ = inferred_stypes[eid];
   }
 }
 

--- a/src/ngraph/ngraph_compiler.cc
+++ b/src/ngraph/ngraph_compiler.cc
@@ -105,9 +105,7 @@ void Compiler::Infer(const BindArg* bind) {
   // append default shapes / dtypes so that vector size = graph size
   shapes_.resize(idx.input_nodes().size(), nnvm::TShape());
   dtypes_.resize(idx.input_nodes().size(), -1);
-  /* std::cout << "stype resize: " << stypes_.size(); */
   stypes_.resize(idx.input_nodes().size(), mxnet::kDefaultStorage);
-  /* std::cout << ":"<<stypes_.size() <<std::endl; */
 }
 
 // infer nnvm::Graph shape and dtype for simple bind case

--- a/src/ngraph/ngraph_compiler.cc
+++ b/src/ngraph/ngraph_compiler.cc
@@ -114,7 +114,7 @@ void Compiler::Infer(const SimpleBindArg* simplebind) {
   const auto& idx = graph_.indexed_graph();
   shapes_.resize(idx.input_nodes().size(), nnvm::TShape());
   dtypes_.resize(idx.input_nodes().size(), -1);
-  stypes_.resize(idx.input_nodes().size(), -1);
+  stypes_.resize(idx.input_nodes().size(), mxnet::kDefaultStorage);
   size_t arg_top = 0, aux_top = 0;
   for (size_t i = 0; i < simplebind->kNumForwardInputs; ++i) {
     const uint32_t nid = idx.input_nodes().at(i);

--- a/src/ngraph/ngraph_compiler.h
+++ b/src/ngraph/ngraph_compiler.h
@@ -208,7 +208,7 @@ class Compiler {
   nnvm::Graph graph_;
   // storage for IR graph
   ngraph_bridge::Graph ngraph_;
-  // shape, type, storage_type maps to return to the graph executor
+  // shape, type and storage_type maps to return to the graph executor
   NgraphShape ngraph_shape_;
   NgraphDType ngraph_dtype_;
   NgraphDType ngraph_stype_;

--- a/src/ngraph/ngraph_compiler.h
+++ b/src/ngraph/ngraph_compiler.h
@@ -41,6 +41,7 @@ using NodeMap = std::map<const nnvm::Node*, std::shared_ptr<nnvm::Node>>;
 using NNVMNodeVec = std::vector<nnvm::NodePtr>;
 using NgraphShape = std::unordered_map<std::string, nnvm::TShape>;
 using NgraphDType = std::unordered_map<std::string, int>;
+using NgraphSType = std::unordered_map<std::string, int>;
 using NDArrayMap = nnvm::NodeEntryMap<mxnet::NDArray>;
 using StateMap = std::unordered_map<const nnvm::Node*, mxnet::OpStatePtr>;
 
@@ -73,12 +74,17 @@ struct BindArg : public BindArgBase {
 struct SimpleBindArg : public BindArgBase {
   SimpleBindArg(size_t numforward,
                 const std::unordered_map<std::string, nnvm::TShape>& shapes,
-                const std::unordered_map<std::string, int>& dtypes)
-      : BindArgBase(numforward), shape_map_(shapes), dtype_map_(dtypes) {}
+                const std::unordered_map<std::string, int>& dtypes,
+                const std::unordered_map<std::string, int>& stypes)
+      : BindArgBase(numforward),
+        shape_map_(shapes),
+        dtype_map_(dtypes),
+        stype_map_(stypes) {}
 
   // simple bind arguments
   const NgraphShape shape_map_;
   const NgraphDType dtype_map_;
+  const NgraphDType stype_map_;
 };
 
 // This is a compile-time hash map that contains information on
@@ -174,6 +180,7 @@ class Compiler {
   // Return maps of the shapes and dtypes for further analysis in graph_executor
   const NgraphShape& GetNgraphShape() { return ngraph_shape_; }
   const NgraphDType& GetNgraphDtype() { return ngraph_dtype_; }
+  const NgraphSType& GetNgraphStype() { return ngraph_stype_; }
   // Return copies of the feed_dict and inputs to feed back into the
   // graph executor inference engine
   const NDArrayMap& GetFeedDict() { return feed_dict_; }
@@ -201,9 +208,10 @@ class Compiler {
   nnvm::Graph graph_;
   // storage for IR graph
   ngraph_bridge::Graph ngraph_;
-  // shape and type maps to return to the graph executor
+  // shape, type, storage_type maps to return to the graph executor
   NgraphShape ngraph_shape_;
   NgraphDType ngraph_dtype_;
+  NgraphDType ngraph_stype_;
   // copied feed dict and inputs
   nnvm::NodeEntryMap<mxnet::NDArray> feed_dict_;
   NNVMNodeVec inputs_;
@@ -217,6 +225,8 @@ class Compiler {
   nnvm::ShapeVector shapes_;
   // inferred nnvm::Graph dtype
   nnvm::DTypeVector dtypes_;
+  // inferred nnvm::Graph storage type
+  nnvm::StorageVector stypes_;
 };
 
 }  // namespace ngraph_bridge

--- a/src/ngraph/ngraph_emitter.cc
+++ b/src/ngraph/ngraph_emitter.cc
@@ -22,7 +22,7 @@
 #include <utility>
 #include <vector>
 
-#include <ngraph/ops/get_output_element.hpp>
+#include <ngraph/op/get_output_element.hpp>
 #include "ngraph_sgcompiler_utils.h"
 
 namespace ngraph_bridge {

--- a/src/ngraph/ngraph_emitter.cc
+++ b/src/ngraph/ngraph_emitter.cc
@@ -22,7 +22,6 @@
 #include <utility>
 #include <vector>
 
-#include <ngraph/ops/batch_norm.hpp>
 #include <ngraph/ops/get_output_element.hpp>
 #include "ngraph_sgcompiler_utils.h"
 

--- a/src/ngraph/ngraph_emitter.cc
+++ b/src/ngraph/ngraph_emitter.cc
@@ -445,42 +445,36 @@ void Emitter::CreateBinaryOps() {
         std::make_shared<ngraph::op::Equal>(op_map_[node->inputs_[0]],
                                             op_map_[node->inputs_[1]]),
         getType(node->dtype_));
-
   };
   ngraph_op_funcs_["_not_equal"] = [this](const NodePtr& node) {
     return cast_result(
         std::make_shared<ngraph::op::NotEqual>(op_map_[node->inputs_[0]],
                                                op_map_[node->inputs_[1]]),
         getType(node->dtype_));
-
   };
   ngraph_op_funcs_["_greater"] = [this](const NodePtr& node) {
     return cast_result(
         std::make_shared<ngraph::op::Greater>(op_map_[node->inputs_[0]],
                                               op_map_[node->inputs_[1]]),
         getType(node->dtype_));
-
   };
   ngraph_op_funcs_["_greater_equal"] = [this](const NodePtr& node) {
     return cast_result(
         std::make_shared<ngraph::op::GreaterEq>(op_map_[node->inputs_[0]],
                                                 op_map_[node->inputs_[1]]),
         getType(node->dtype_));
-
   };
   ngraph_op_funcs_["_lesser"] = [this](const NodePtr& node) {
     return cast_result(
         std::make_shared<ngraph::op::Less>(op_map_[node->inputs_[0]],
                                            op_map_[node->inputs_[1]]),
         getType(node->dtype_));
-
   };
   ngraph_op_funcs_["_lesser_equal"] = [this](const NodePtr& node) {
     return cast_result(
         std::make_shared<ngraph::op::LessEq>(op_map_[node->inputs_[0]],
                                              op_map_[node->inputs_[1]]),
         getType(node->dtype_));
-
   };
   auto dot_transpose = [this](const NodePtr& node, NgraphNodePtr left,
                               NgraphNodePtr right) {
@@ -595,22 +589,18 @@ void Emitter::CreateBinaryOps() {
   ngraph_op_funcs_["broadcast_greater"] = [this](const NodePtr& node) {
     return cast_result(CreateAutoBroadcast<ngraph::op::Greater>(node),
                        getType(node->dtype_));
-
   };
   ngraph_op_funcs_["broadcast_greater_equal"] = [this](const NodePtr& node) {
     return cast_result(CreateAutoBroadcast<ngraph::op::GreaterEq>(node),
                        getType(node->dtype_));
-
   };
   ngraph_op_funcs_["broadcast_lesser"] = [this](const NodePtr& node) {
     return cast_result(CreateAutoBroadcast<ngraph::op::Less>(node),
                        getType(node->dtype_));
-
   };
   ngraph_op_funcs_["broadcast_lesser_equal"] = [this](const NodePtr& node) {
     return cast_result(CreateAutoBroadcast<ngraph::op::LessEq>(node),
                        getType(node->dtype_));
-
   };
 }
 

--- a/src/ngraph/ngraph_graph.cc
+++ b/src/ngraph/ngraph_graph.cc
@@ -317,6 +317,7 @@ void CollapseSubgraphs(Graph* graph) {
       auto output = tmpGraph->nodes_.back();
       tmpGraph->shape_ = output->shape_;
       tmpGraph->dtype_ = output->dtype_;
+      tmpGraph->stype_ = output->stype_;
 
       auto in_tmpGraphInputs = [&tmpGraph](NodePtr n) {
         if (!in_vec(tmpGraph->inputs_, n)) return false;

--- a/src/ngraph/ngraph_graph.h
+++ b/src/ngraph/ngraph_graph.h
@@ -80,6 +80,7 @@ class Node {
   // mxnet type information
   nnvm::TShape shape_;
   int dtype_ = 0;
+  int stype_ = 0;
 
   // information to store graph parsing in
   size_t multi_output_index_ = 0;

--- a/src/ngraph/ngraph_imperative.cc
+++ b/src/ngraph/ngraph_imperative.cc
@@ -65,9 +65,12 @@ NGImperative::NGImperative(const nnvm::NodeAttrs &attrs,
   for (auto i : inputs) {
     shapes_.push_back(i.shape());
     dtypes_.push_back(i.dtype());
+    stypes_.push_back(mxnet::kDefaultStorage);
   }
   // initialize ngraph
   DeepCopy(g);
+  graph_.attrs["context"] = std::make_shared<nnvm::any>(
+      mxnet::exec::ContextVector(graph_.indexed_graph().num_nodes(), ctx));
   MakeCopiedInputs(sym.ListInputs(nnvm::Symbol::kReadOnlyArgs));
 }
 
@@ -114,7 +117,6 @@ void InitImperativeOnce() {
                         const std::vector<mxnet::NDArray> &outputs) -> void {
             // thread local cache for ngraph op
             static thread_local NGIOpCache ngicache;
-
             auto op_key = get_ngiop_key(attrs, ctx.run_ctx.ctx, inputs);
             auto op_ng = ngicache[op_key];
             if (!op_ng) {

--- a/src/ngraph/ngraph_imperative.h
+++ b/src/ngraph/ngraph_imperative.h
@@ -17,6 +17,7 @@
 #ifndef MXNET_NGRAPH_NGRAPH_IMPERATIVE_H_
 #define MXNET_NGRAPH_NGRAPH_IMPERATIVE_H_
 
+#include <mxnet/ndarray.h>
 #include <nnvm/op.h>
 #include <string>
 #include <tuple>
@@ -35,9 +36,9 @@ class NGImperative : public Compiler {
  public:
   // NGImperative constructor for mxnet compute kernel(s)
   NGImperative(const nnvm::NodeAttrs &attrs, const mxnet::Context &ctx,
-               const std::vector<mxnet::TBlob> &inputs,
+               const std::vector<mxnet::NDArray> &inputs,
                const std::vector<mxnet::OpReqType> *req,
-               const std::vector<mxnet::TBlob> &outputs);
+               const std::vector<mxnet::NDArray> &outputs);
 
   // return ngraph representing the imperative compute kernel
   inline std::shared_ptr<Graph> get_op_ngraph() {
@@ -75,7 +76,7 @@ using NGIOpKey = std::tuple<const std::string, const std::pair<int, int>,
 
 // create NGIOpKey for a given NNVM FCompute kernel.
 NGIOpKey get_ngiop_key(const nnvm::NodeAttrs &attrs, const mxnet::Context &ctx,
-                       const std::vector<mxnet::TBlob> &inputs);
+                       const std::vector<mxnet::NDArray> &inputs);
 
 // ngraph cache for imperative ops
 // TODO(aemani): potential optimizations w/ LRU, fixed size.

--- a/src/ngraph/ngraph_nnvm_ops.cc
+++ b/src/ngraph/ngraph_nnvm_ops.cc
@@ -250,6 +250,15 @@ void register_forward_op(std::shared_ptr<Graph> graph) {
         return mxnet::op::type_assign(&((*oattr)[0]), dtype);
       });
 
+  op.set_attr<mxnet::FInferStorageType>(
+      "FInferStorageType",
+      [](const nnvm::NodeAttrs &attrs, const int dev_mask,
+         mxnet::DispatchMode *dispatch_mode, std::vector<int> *in_attrs,
+         std::vector<int> *out_attrs) {
+        return mxnet::op::storage_type_assign(out_attrs, mxnet::kDefaultStorage,
+                                              dispatch_mode,
+                                              mxnet::DispatchMode::kFComputeEx);
+      });
   // create the compute lambda
   op.set_attr<mxnet::FComputeEx>(
       "FComputeEx<cpu>",
@@ -273,6 +282,15 @@ void register_backward_op(std::shared_ptr<Graph> graph) {
   // Mark as backward
   op.set_attr<bool>("TIsBackward", true);
 
+  op.set_attr<mxnet::FInferStorageType>(
+      "FInferStorageType",
+      [](const nnvm::NodeAttrs &attrs, const int dev_mask,
+         mxnet::DispatchMode *dispatch_mode, std::vector<int> *in_attrs,
+         std::vector<int> *out_attrs) {
+        return mxnet::op::storage_type_assign(out_attrs, mxnet::kDefaultStorage,
+                                              dispatch_mode,
+                                              mxnet::DispatchMode::kFComputeEx);
+      });
   // create the compute lambda
   op.set_attr<mxnet::FComputeEx>(
       "FComputeEx<cpu>",

--- a/src/ngraph/ngraph_nnvm_ops.cc
+++ b/src/ngraph/ngraph_nnvm_ops.cc
@@ -53,9 +53,9 @@ void append_cached_to_forward(TensorViewVector *results,
 
 // function for computing forward on ngraph
 void compute_forward(const mxnet::OpContext &ctx, std::shared_ptr<Graph> graph,
-                     const std::vector<mxnet::TBlob> &inputs,
+                     const std::vector<mxnet::NDArray> &inputs,
                      const std::vector<mxnet::OpReqType> &req,
-                     const std::vector<mxnet::TBlob> &outputs) {
+                     const std::vector<mxnet::NDArray> &outputs) {
   auto backend = GetBackendFromContext(graph->context_);
   auto placeholders = make_ngraph_placeholders(inputs, backend, true);
   auto results = make_ngraph_placeholders(outputs, backend, false);
@@ -69,15 +69,15 @@ void compute_forward(const mxnet::OpContext &ctx, std::shared_ptr<Graph> graph,
   append_cached_to_forward(&results, graph, mode);
   graph->ngraph_forward[mode]->call(placeholders, results);
 
-  std::vector<mxnet::TBlob> outs = {outputs[0]};
-  result_to_TBlob(results, req, outs);
+  std::vector<mxnet::NDArray> outs = {outputs[0]};
+  result_to_NDArray(results, req, outs);
 }
 
 // function for computing backward on ngraph
 void compute_backward(const mxnet::OpContext &ctx, std::shared_ptr<Graph> graph,
-                      const std::vector<mxnet::TBlob> &inputs,
+                      const std::vector<mxnet::NDArray> &inputs,
                       const std::vector<mxnet::OpReqType> &req,
-                      const std::vector<mxnet::TBlob> &outputs) {
+                      const std::vector<mxnet::NDArray> &outputs) {
   // only expect backward is called in training mode
   assert(ctx.is_train);
   auto backend = GetBackendFromContext(graph->context_);
@@ -88,8 +88,8 @@ void compute_backward(const mxnet::OpContext &ctx, std::shared_ptr<Graph> graph,
   // generate valid data in fprop cache
   if (graph->enable_fprop_cache && !graph->forward_train_computed) {
     // forward inputs
-    std::vector<mxnet::TBlob> fwd_inputs(inputs.begin() + graph->num_outputs,
-                                         inputs.end());
+    std::vector<mxnet::NDArray> fwd_inputs(inputs.begin() + graph->num_outputs,
+                                           inputs.end());
     auto placeholders = make_ngraph_placeholders(fwd_inputs, backend, true);
     // forward outputs
     auto shape = TShape_to_NShape(graph->nodes_.back()->shape_);
@@ -113,21 +113,21 @@ void compute_backward(const mxnet::OpContext &ctx, std::shared_ptr<Graph> graph,
   // reset the forward training compute flag to ensure backward always have
   // updated data from forward
   graph->forward_train_computed = false;
-  result_to_TBlob(results, req, outputs);
+  result_to_NDArray(results, req, outputs);
 
   // overwrite aux data if they exist
   // aux result outputs mapped to inputs
   const size_t cached_aux_count = graph->cached_aux_values[mode].size();
   if (cached_aux_count > 0) {
     std::vector<mxnet::OpReqType> aux_req;
-    std::vector<mxnet::TBlob> aux_outs;
+    std::vector<mxnet::NDArray> aux_outs;
 
     for (size_t i = 0; i < cached_aux_count; ++i) {
       aux_outs.push_back(inputs[graph->cached_aux_positions[mode][i] + 1]);
       aux_req.push_back(mxnet::kWriteTo);
     }
 
-    result_to_TBlob(graph->cached_aux_values[mode], aux_req, aux_outs);
+    result_to_NDArray(graph->cached_aux_values[mode], aux_req, aux_outs);
   }
 }
 
@@ -251,12 +251,12 @@ void register_forward_op(std::shared_ptr<Graph> graph) {
       });
 
   // create the compute lambda
-  op.set_attr<mxnet::FCompute>(
-      "FCompute<cpu>",
+  op.set_attr<mxnet::FComputeEx>(
+      "FComputeEx<cpu>",
       [graph](const nnvm::NodeAttrs &attrs, const mxnet::OpContext &ctx,
-              const std::vector<mxnet::TBlob> &inputs,
+              const std::vector<mxnet::NDArray> &inputs,
               const std::vector<mxnet::OpReqType> &req,
-              const std::vector<mxnet::TBlob> &outputs) -> void {
+              const std::vector<mxnet::NDArray> &outputs) -> void {
         compute_forward(ctx, graph, inputs, req, outputs);
       });
 }
@@ -274,12 +274,12 @@ void register_backward_op(std::shared_ptr<Graph> graph) {
   op.set_attr<bool>("TIsBackward", true);
 
   // create the compute lambda
-  op.set_attr<mxnet::FCompute>(
-      "FCompute<cpu>",
+  op.set_attr<mxnet::FComputeEx>(
+      "FComputeEx<cpu>",
       [graph](const nnvm::NodeAttrs &attrs, const mxnet::OpContext &ctx,
-              const std::vector<mxnet::TBlob> &inputs,
+              const std::vector<mxnet::NDArray> &inputs,
               const std::vector<mxnet::OpReqType> &req,
-              const std::vector<mxnet::TBlob> &outputs) -> void {
+              const std::vector<mxnet::NDArray> &outputs) -> void {
         compute_backward(ctx, graph, inputs, req, outputs);
       });
 }

--- a/src/ngraph/ngraph_nnvm_ops.cc
+++ b/src/ngraph/ngraph_nnvm_ops.cc
@@ -67,7 +67,7 @@ void compute_forward(const mxnet::OpContext &ctx, std::shared_ptr<Graph> graph,
   }
   assert(graph->ngraph_forward[mode] != nullptr);
   append_cached_to_forward(&results, graph, mode);
-  graph->ngraph_forward[mode]->call(placeholders, results);
+  graph->ngraph_forward[mode]->call(results, placeholders);
 
   std::vector<mxnet::NDArray> outs = {outputs[0]};
   result_to_NDArray(results, req, outs);
@@ -98,7 +98,7 @@ void compute_backward(const mxnet::OpContext &ctx, std::shared_ptr<Graph> graph,
     TensorViewVector results{output_tv};
     append_cached_to_forward(&results, graph, mode);
     // call forward
-    graph->ngraph_forward[mode]->call(placeholders, results);
+    graph->ngraph_forward[mode]->call(results, placeholders);
   }
 
   // backward op
@@ -109,7 +109,7 @@ void compute_backward(const mxnet::OpContext &ctx, std::shared_ptr<Graph> graph,
   auto results = make_ngraph_placeholders(outputs, backend, false);
   placeholders.insert(placeholders.end(), graph->cached_values[mode].begin(),
                       graph->cached_values[mode].end());
-  graph->ngraph_backward[mode]->call(placeholders, results);
+  graph->ngraph_backward[mode]->call(results, placeholders);
   // reset the forward training compute flag to ensure backward always have
   // updated data from forward
   graph->forward_train_computed = false;

--- a/src/ngraph/ngraph_nnvm_ops.h
+++ b/src/ngraph/ngraph_nnvm_ops.h
@@ -17,6 +17,7 @@
 #ifndef MXNET_NGRAPH_NGRAPH_NNVM_OPS_H_
 #define MXNET_NGRAPH_NGRAPH_NNVM_OPS_H_
 
+#include <mxnet/ndarray.h>
 #include <mxnet/op_attr_types.h>
 #include <nnvm/op.h>
 
@@ -32,14 +33,14 @@ nnvm::Op* get_subgraph_op(std::shared_ptr<Graph> graph);
 void register_subgraph(std::shared_ptr<Graph> graph);
 // function for computing forward on ngraph
 void compute_forward(const mxnet::OpContext& ctx, std::shared_ptr<Graph> graph,
-                     const std::vector<mxnet::TBlob>& inputs,
+                     const std::vector<mxnet::NDArray>& inputs,
                      const std::vector<mxnet::OpReqType>& req,
-                     const std::vector<mxnet::TBlob>& outputs);
+                     const std::vector<mxnet::NDArray>& outputs);
 // function for computing backward on ngraph
 void compute_backward(const mxnet::OpContext& ctx, std::shared_ptr<Graph> graph,
-                      const std::vector<mxnet::TBlob>& inputs,
+                      const std::vector<mxnet::NDArray>& inputs,
                       const std::vector<mxnet::OpReqType>& req,
-                      const std::vector<mxnet::TBlob>& outputs);
+                      const std::vector<mxnet::NDArray>& outputs);
 
 // dummy parameter struct to match mxnet API
 struct NGraphParam {

--- a/src/ngraph/ngraph_nnvm_utils.h
+++ b/src/ngraph/ngraph_nnvm_utils.h
@@ -17,6 +17,7 @@
 #ifndef MXNET_NGRAPH_NGRAPH_NNVM_UTILS_H_
 #define MXNET_NGRAPH_NGRAPH_NNVM_UTILS_H_
 
+#include <mxnet/ndarray.h>
 #include <mxnet/op_attr_types.h>
 
 #include <algorithm>
@@ -42,17 +43,17 @@ inline size_t get_buffer_size(const T& shape, size_t nbytes) {
 // This function creates an ngraph Tensor from the shape and type
 // of an input mxnet TBlob. It optionally copies the data
 // from the TBlob to the ngraph tensor.
-inline std::shared_ptr<TensorView> TBlob_to_TensorView(
-    const mxnet::TBlob& input,
+inline std::shared_ptr<TensorView> NDArray_to_TensorView(
+    const mxnet::NDArray& input,
     std::shared_ptr<ngraph::runtime::Backend> backend, bool copy) {
-  auto shape = TShape_to_NShape(input.shape_);
-  const auto& element_type = getType(input.type_flag_);
+  auto shape = TShape_to_NShape(input.shape());
+  const auto& element_type = getType(input.dtype());
 
   auto TV = backend->make_primary_tensor_view(element_type, shape);
 
   if (copy) {
     auto buffer_size = get_buffer_size(shape, element_type.size());
-    TV->write(input.dptr_, 0, buffer_size);
+    TV->write(input.storage_handle().dptr, 0, buffer_size);
   }
 
   return TV;
@@ -63,55 +64,55 @@ inline std::shared_ptr<TensorView> TBlob_to_TensorView(
 // equialently shaped and typed ngraph tensors, optionally
 // copied the data from the TBlobs to ngraph
 inline TensorViewVector make_ngraph_placeholders(
-    const std::vector<mxnet::TBlob>& inputs,
+    const std::vector<mxnet::NDArray>& inputs,
     std::shared_ptr<ngraph::runtime::Backend> backend, bool copy_data) {
   TensorViewVector out;
   std::transform(inputs.begin(), inputs.end(), std::back_inserter(out),
-                 [copy_data, backend](const mxnet::TBlob& tb) {
-                   return TBlob_to_TensorView(tb, backend, copy_data);
+                 [copy_data, backend](const mxnet::NDArray& input) {
+                   return NDArray_to_TensorView(input, backend, copy_data);
                  });
   return out;
 }
 
 template <class T>
-inline void result_plus_TBlob(void* mxnet_tblob, void* ngraph_tv,
-                              size_t buffer_size) {
-  T* mxnet_tblob_tptr = static_cast<T*>(mxnet_tblob);
-  T* ngraph_tv_tptr = static_cast<T*>(ngraph_tv);
+inline void result_plus_NDArray(void* mxnet_ptr, void* ngraph_ptr,
+                                size_t buffer_size) {
+  T* mxnet_ptr_tptr = static_cast<T*>(mxnet_ptr);
+  T* ngraph_ptr_tptr = static_cast<T*>(ngraph_ptr);
   for (size_t i = 0; i < (buffer_size / sizeof(T)); ++i) {
-    *(mxnet_tblob_tptr + i) += *(ngraph_tv_tptr + i);
+    *(mxnet_ptr_tptr + i) += *(ngraph_ptr_tptr + i);
   }
 }
 
 // Utility function that copies all results from an
-// ngraph computation into the output TBlobs in mxnet
-inline void result_to_TBlob(
+// ngraph computation into the output NDArrays in mxnet
+inline void result_to_NDArray(
     const std::vector<std::shared_ptr<ngraph::runtime::TensorView>>& results,
     const std::vector<mxnet::OpReqType>& req,
-    const std::vector<mxnet::TBlob>& outputs) {
+    const std::vector<mxnet::NDArray>& outputs) {
   for (size_t i = 0; i < outputs.size(); ++i) {
     if (req[i] == mxnet::kNullOp) continue;
 
-    const auto& element_type = getType(outputs[i].type_flag_);
-    auto buffer_size = get_buffer_size(outputs[i].shape_, element_type.size());
+    const auto& element_type = getType(outputs[i].dtype());
+    auto buffer_size = get_buffer_size(outputs[i].shape(), element_type.size());
 
-    void* mxnet_tblob = outputs[i].dptr_;
+    void* mxnet_tblob = outputs[i].storage_handle().dptr;
     if (req[i] == mxnet::kAddTo) {
       void* ngraph_tv = malloc(buffer_size);
       results[i]->read(ngraph_tv, 0, buffer_size);
 
       if (element_type == ngraph::element::f32)
-        result_plus_TBlob<float>(mxnet_tblob, ngraph_tv, buffer_size);
+        result_plus_NDArray<float>(mxnet_tblob, ngraph_tv, buffer_size);
       else if (element_type == ngraph::element::f64)
-        result_plus_TBlob<double>(mxnet_tblob, ngraph_tv, buffer_size);
+        result_plus_NDArray<double>(mxnet_tblob, ngraph_tv, buffer_size);
       else if (element_type == ngraph::element::u8)
-        result_plus_TBlob<uint8_t>(mxnet_tblob, ngraph_tv, buffer_size);
+        result_plus_NDArray<uint8_t>(mxnet_tblob, ngraph_tv, buffer_size);
       else if (element_type == ngraph::element::i8)
-        result_plus_TBlob<int8_t>(mxnet_tblob, ngraph_tv, buffer_size);
+        result_plus_NDArray<int8_t>(mxnet_tblob, ngraph_tv, buffer_size);
       else if (element_type == ngraph::element::i32)
-        result_plus_TBlob<int32_t>(mxnet_tblob, ngraph_tv, buffer_size);
+        result_plus_NDArray<int32_t>(mxnet_tblob, ngraph_tv, buffer_size);
       else if (element_type == ngraph::element::i64)
-        result_plus_TBlob<int64_t>(mxnet_tblob, ngraph_tv, buffer_size);
+        result_plus_NDArray<int64_t>(mxnet_tblob, ngraph_tv, buffer_size);
 
       free(ngraph_tv);
     } else {

--- a/src/ngraph/ngraph_nnvm_utils.h
+++ b/src/ngraph/ngraph_nnvm_utils.h
@@ -96,28 +96,28 @@ inline void result_to_NDArray(
     const auto& element_type = getType(outputs[i].dtype());
     auto buffer_size = get_buffer_size(outputs[i].shape(), element_type.size());
 
-    void* mxnet_tblob = outputs[i].storage_handle().dptr;
+    void* mxnet_ndarray = outputs[i].storage_handle().dptr;
     if (req[i] == mxnet::kAddTo) {
       void* ngraph_tv = malloc(buffer_size);
       results[i]->read(ngraph_tv, 0, buffer_size);
 
       if (element_type == ngraph::element::f32)
-        result_plus_NDArray<float>(mxnet_tblob, ngraph_tv, buffer_size);
+        result_plus_NDArray<float>(mxnet_ndarray, ngraph_tv, buffer_size);
       else if (element_type == ngraph::element::f64)
-        result_plus_NDArray<double>(mxnet_tblob, ngraph_tv, buffer_size);
+        result_plus_NDArray<double>(mxnet_ndarray, ngraph_tv, buffer_size);
       else if (element_type == ngraph::element::u8)
-        result_plus_NDArray<uint8_t>(mxnet_tblob, ngraph_tv, buffer_size);
+        result_plus_NDArray<uint8_t>(mxnet_ndarray, ngraph_tv, buffer_size);
       else if (element_type == ngraph::element::i8)
-        result_plus_NDArray<int8_t>(mxnet_tblob, ngraph_tv, buffer_size);
+        result_plus_NDArray<int8_t>(mxnet_ndarray, ngraph_tv, buffer_size);
       else if (element_type == ngraph::element::i32)
-        result_plus_NDArray<int32_t>(mxnet_tblob, ngraph_tv, buffer_size);
+        result_plus_NDArray<int32_t>(mxnet_ndarray, ngraph_tv, buffer_size);
       else if (element_type == ngraph::element::i64)
-        result_plus_NDArray<int64_t>(mxnet_tblob, ngraph_tv, buffer_size);
+        result_plus_NDArray<int64_t>(mxnet_ndarray, ngraph_tv, buffer_size);
 
       free(ngraph_tv);
     } else {
       // TODO(adstraw): Add support for kWriteInplace
-      results[i]->read(mxnet_tblob, 0, buffer_size);
+      results[i]->read(mxnet_ndarray, 0, buffer_size);
     }
   }
 }

--- a/src/ngraph/ngraph_utils.h
+++ b/src/ngraph/ngraph_utils.h
@@ -16,6 +16,7 @@
 
 #ifndef MXNET_NGRAPH_NGRAPH_UTILS_H_
 #define MXNET_NGRAPH_NGRAPH_UTILS_H_
+#include <mxnet/ndarray.h>
 #include <chrono>
 #include <iostream>
 #include <string>
@@ -146,6 +147,14 @@ inline bool get_default(const NodePtr& node, const std::string& key,
       return false;
   }
   return default_val;
+}
+
+// check if any ndarray is sparse
+inline bool sparse_check(const std::vector<mxnet::NDArray>& ndarray) {
+  for (const auto& i : ndarray) {
+    if (i.storage_type() != mxnet::kDefaultStorage) return true;
+  }
+  return false;
 }
 
 template <typename T>

--- a/tests/cpp/ngraph/test_ngraph_compiler.h
+++ b/tests/cpp/ngraph/test_ngraph_compiler.h
@@ -62,6 +62,7 @@ class NGRAPH_COMPILER : public ::testing::Test {
 
     nnvm::TShape shape{2, 2};
     std::unordered_map<std::string, int> dtypes;
+    std::unordered_map<std::string, int> stypes;
     std::unordered_map<std::string, nnvm::TShape> shapes;
 
     for (auto n : {A, B, C, D}) inputs.push_back(n.node);
@@ -69,9 +70,11 @@ class NGRAPH_COMPILER : public ::testing::Test {
     for (auto n : {"A", "B", "C", "D"}) {
       dtypes[n] = 0;
       shapes[n] = shape;
+      stypes[n] = mxnet::kDefaultStorage;
     }
     feed_dict[A] = mxnet::NDArray(shape, mxnet::Context());
-    bindarg = std::make_shared<ngraph_bridge::SimpleBindArg>(4, shapes, dtypes);
+    bindarg = std::make_shared<ngraph_bridge::SimpleBindArg>(4, shapes, dtypes,
+                                                             stypes);
   }
 
   virtual void TearDown() {}

--- a/tests/cpp/ngraph/test_ngraph_graph.cc
+++ b/tests/cpp/ngraph/test_ngraph_graph.cc
@@ -72,40 +72,43 @@ TEST_F(NGRAPH_GRAPH, CYCLIC_GRAPH) {
 }
 
 TEST_F(NGRAPH_GRAPH, GRAPH_DFS_LINEAR) {
-  EXPECT_EQ(SelectNodes(linear_graph.nodes_[4], isop).size(), 4);
-  EXPECT_EQ(SelectNodes(linear_graph.nodes_[3], isop).size(), 3);
-  EXPECT_EQ(SelectNodes(linear_graph.nodes_[0], isop).size(), 0);
+  EXPECT_EQ(SelectNodes(linear_graph.nodes_[4], isop).size(), 4ul);
+  EXPECT_EQ(SelectNodes(linear_graph.nodes_[3], isop).size(), 3ul);
+  EXPECT_EQ(SelectNodes(linear_graph.nodes_[0], isop).size(), 0ul);
 }
 
 TEST_F(NGRAPH_GRAPH, GRAPH_DFS_BRANCHING) {
-  EXPECT_EQ(SelectNodes(branching_graph.nodes_[1], isop).size(), 1);
-  EXPECT_EQ(SelectNodes(branching_graph.nodes_[2], isop).size(), 2);
-  EXPECT_EQ(SelectNodes(branching_graph.nodes_[4], isop).size(), 3);
-  EXPECT_EQ(SelectNodes(branching_graph.nodes_[5], isop).size(), 4);
+  EXPECT_EQ(SelectNodes(branching_graph.nodes_[1], isop).size(), 1ul);
+  EXPECT_EQ(SelectNodes(branching_graph.nodes_[2], isop).size(), 2ul);
+  EXPECT_EQ(SelectNodes(branching_graph.nodes_[4], isop).size(), 3ul);
+  EXPECT_EQ(SelectNodes(branching_graph.nodes_[5], isop).size(), 4ul);
 }
 
 TEST_F(NGRAPH_GRAPH, GRAPH_FIND_SUBGRAPH) {
   // branching
   EXPECT_EQ(
-      FindSubgraph(branching_graph, branching_graph.nodes_[2], isop).size(), 1);
+      FindSubgraph(branching_graph, branching_graph.nodes_[2], isop).size(),
+      1ul);
   EXPECT_EQ(
-      FindSubgraph(branching_graph, branching_graph.nodes_[4], isop).size(), 2);
+      FindSubgraph(branching_graph, branching_graph.nodes_[4], isop).size(),
+      2ul);
   EXPECT_EQ(
-      FindSubgraph(branching_graph, branching_graph.nodes_[5], isop).size(), 3);
+      FindSubgraph(branching_graph, branching_graph.nodes_[5], isop).size(),
+      3ul);
   // multi
-  EXPECT_EQ(FindSubgraph(multi_graph, multi_graph.nodes_[2], isop).size(), 1);
-  EXPECT_EQ(FindSubgraph(multi_graph, multi_graph.nodes_[4], isop).size(), 1);
-  EXPECT_EQ(FindSubgraph(multi_graph, multi_graph.nodes_[5], isop).size(), 1);
-  EXPECT_EQ(FindSubgraph(multi_graph, multi_graph.nodes_[7], isop).size(), 2);
+  EXPECT_EQ(FindSubgraph(multi_graph, multi_graph.nodes_[2], isop).size(), 1ul);
+  EXPECT_EQ(FindSubgraph(multi_graph, multi_graph.nodes_[4], isop).size(), 1ul);
+  EXPECT_EQ(FindSubgraph(multi_graph, multi_graph.nodes_[5], isop).size(), 1ul);
+  EXPECT_EQ(FindSubgraph(multi_graph, multi_graph.nodes_[7], isop).size(), 2ul);
   // complex
   EXPECT_EQ(FindSubgraph(complex_graph, complex_graph.nodes_[9], isop).size(),
-            1);
+            1ul);
   EXPECT_EQ(FindSubgraph(complex_graph, complex_graph.nodes_[20], isop).size(),
-            3);
+            3ul);
   EXPECT_EQ(FindSubgraph(complex_graph, complex_graph.nodes_[24], isop).size(),
-            6);
+            6ul);
   EXPECT_EQ(FindSubgraph(complex_graph, complex_graph.nodes_[25], isop).size(),
-            6);
+            6ul);
 }
 
 TEST_F(NGRAPH_GRAPH, GRAPH_IDENTIFY_SUBGRAPHS) {
@@ -123,11 +126,11 @@ TEST_F(NGRAPH_GRAPH, GRAPH_COLLAPSE_SUBGRAPHS) {
   IdentifySubgraphs(branching_graph, isop);
   CollapseSubgraphs(&branching_graph);
   auto size = branching_graph.nodes_.size();
-  EXPECT_EQ(size, 5);
+  EXPECT_EQ(size, 5ul);
   auto subgraph =
       std::dynamic_pointer_cast<Graph>(branching_graph.nodes_[size - 2]);
   EXPECT_NE(subgraph, nullptr);
-  EXPECT_EQ(subgraph->nodes_.size(), 3);
+  EXPECT_EQ(subgraph->nodes_.size(), 3ul);
 }
 
 // TEST(NGRAPH_GRAPH, PARSENNVM) {

--- a/tests/cpp/ngraph/test_ngraph_imperative.cc
+++ b/tests/cpp/ngraph/test_ngraph_imperative.cc
@@ -14,8 +14,8 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "test_ngraph_imperative.h"
 #include "../../src/ngraph/ngraph_nnvm_ops.h"
+#include "test_ngraph_imperative.h"
 
 namespace ngraph_bridge {
 
@@ -42,7 +42,7 @@ TEST_F(NGRAPH_IMPERATIVE, SYMBOL_GRAPH) {
 
 TEST_F(NGRAPH_IMPERATIVE, PARSE_OPGRAPH) {
   testImperative test(attrs, mxnet::Context::CPU(), inputs, nullptr, outputs);
-  EXPECT_EQ(test.ngraph_.nodes_.size(), 0);
+  EXPECT_EQ(test.ngraph_.nodes_.size(), 0ul);
   EXPECT_FALSE(test.op_ngraph_);
   test.parse_ngraph();
   EXPECT_TRUE(test.op_ngraph_);
@@ -66,9 +66,9 @@ TEST_F(NGRAPH_IMPERATIVE, UNSUPPORTED_OP) {
   sym_attrs.op = nnvm::Op::Get("IdentityAttachKLSparseReg");
   testImperative test(sym_attrs, mxnet::Context::CPU(), outputs, nullptr,
                       outputs);
-  EXPECT_EQ(test.ngraph_.nodes_.size(), 0);
+  EXPECT_EQ(test.ngraph_.nodes_.size(), 0ul);
   test.parse_ngraph();
-  EXPECT_EQ(test.ngraph_.nodes_.size(), 2);
+  EXPECT_EQ(test.ngraph_.nodes_.size(), 2ul);
   for (auto n : test.ngraph_.nodes_) {
     EXPECT_EQ(n->in_ngraph_, false);
   }

--- a/tests/cpp/ngraph/test_ngraph_imperative.h
+++ b/tests/cpp/ngraph/test_ngraph_imperative.h
@@ -30,9 +30,12 @@ class NGRAPH_IMPERATIVE : public ::testing::Test {
   NGRAPH_IMPERATIVE() {
     // default test arguments
     nnvm::TShape shape{2};
-    inputs.emplace_back(vec1.data(), shape, 0);
-    inputs.emplace_back(vec2.data(), shape, 0);
-    outputs.emplace_back(vec3.data(), shape, 0);
+    inputs.emplace_back(
+        mxnet::NDArray(mxnet::TBlob(vec1.data(), shape, 1, 0), 0));
+    inputs.emplace_back(
+        mxnet::NDArray(mxnet::TBlob(vec2.data(), shape, 1, 0), 0));
+    outputs.emplace_back(
+        mxnet::NDArray(mxnet::TBlob(vec3.data(), shape, 1, 0), 0));
     attrs.op = nnvm::Op::Get(op_name);
   }
   std::string op_name = "broadcast_mul";
@@ -40,8 +43,8 @@ class NGRAPH_IMPERATIVE : public ::testing::Test {
   std::vector<float> vec1{1, 2};
   std::vector<float> vec2{2, 3};
   std::vector<float> vec3{0, 0};
-  std::vector<mxnet::TBlob> inputs;
-  std::vector<mxnet::TBlob> outputs;
+  std::vector<mxnet::NDArray> inputs;
+  std::vector<mxnet::NDArray> outputs;
   std::vector<mxnet::OpReqType> req{mxnet::kWriteTo};
 };
 
@@ -52,9 +55,9 @@ class testImperative : public NGImperative {
   using NGImperative::op_ngraph_;
   using NGImperative::parse_ngraph;
   testImperative(const nnvm::NodeAttrs &attrs, const mxnet::Context &ctx,
-                 const std::vector<mxnet::TBlob> &inputs,
+                 const std::vector<mxnet::NDArray> &inputs,
                  const std::vector<mxnet::OpReqType> *req,
-                 const std::vector<mxnet::TBlob> &outputs)
+                 const std::vector<mxnet::NDArray> &outputs)
       : NGImperative(attrs, ctx, inputs, req, outputs) {}
 };
 }  // namespace ngraph_bridge

--- a/tests/cpp/ngraph/test_ngraph_utils.cc
+++ b/tests/cpp/ngraph/test_ngraph_utils.cc
@@ -48,9 +48,9 @@ TEST(NGRAPH_STRING, GETINTS) {
 }
 
 TEST(NGRAPH_STRING, RANDOMSTRING) {
-  EXPECT_EQ(randomString(12).size(), 12);
-  EXPECT_EQ(randomString(4).size(), 4);
-  EXPECT_EQ(randomString(77).size(), 77);
+  EXPECT_EQ(randomString(12).size(), 12ul);
+  EXPECT_EQ(randomString(4).size(), 4ul);
+  EXPECT_EQ(randomString(77).size(), 77ul);
 }
 
 TEST(NGRAPH_SGCOMPILER_UTILS, Convert_Shapes) {
@@ -85,15 +85,15 @@ TEST(NGRAPH_NNVM, GetBufferSize) {
   ngraph::Shape ngshape{2, 3, 4, 5};
   nnvm::TShape Tshape{2, 3, 4, 5};
 
-  EXPECT_EQ(get_buffer_size(vecshape, 2), 240);
-  EXPECT_EQ(get_buffer_size(vecshape, 4), 480);
-  EXPECT_EQ(get_buffer_size(vecshape, 8), 960);
-  EXPECT_EQ(get_buffer_size(ngshape, 2), 240);
-  EXPECT_EQ(get_buffer_size(ngshape, 4), 480);
-  EXPECT_EQ(get_buffer_size(ngshape, 8), 960);
-  EXPECT_EQ(get_buffer_size(Tshape, 2), 240);
-  EXPECT_EQ(get_buffer_size(Tshape, 4), 480);
-  EXPECT_EQ(get_buffer_size(Tshape, 8), 960);
+  EXPECT_EQ(get_buffer_size(vecshape, 2), 240ul);
+  EXPECT_EQ(get_buffer_size(vecshape, 4), 480ul);
+  EXPECT_EQ(get_buffer_size(vecshape, 8), 960ul);
+  EXPECT_EQ(get_buffer_size(ngshape, 2), 240ul);
+  EXPECT_EQ(get_buffer_size(ngshape, 4), 480ul);
+  EXPECT_EQ(get_buffer_size(ngshape, 8), 960ul);
+  EXPECT_EQ(get_buffer_size(Tshape, 2), 240ul);
+  EXPECT_EQ(get_buffer_size(Tshape, 4), 480ul);
+  EXPECT_EQ(get_buffer_size(Tshape, 8), 960ul);
 }
 
 TEST(NGRAPH_NNVM, copy_NDArrays) {

--- a/tests/cpp/ngraph/test_ngraph_utils.cc
+++ b/tests/cpp/ngraph/test_ngraph_utils.cc
@@ -96,16 +96,16 @@ TEST(NGRAPH_NNVM, GetBufferSize) {
   EXPECT_EQ(get_buffer_size(Tshape, 8), 960);
 }
 
-TEST(NGRAPH_NNVM, copy_TBlobs) {
+TEST(NGRAPH_NNVM, copy_NDArrays) {
   nnvm::TShape shape{10};
   std::vector<float> vec1{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   std::vector<float> vec2{11, 12, 13, 14, 15, 16, 17, 18, 19, 10};
 
-  mxnet::TBlob TBlob1(vec1.data(), shape, 0);
-  mxnet::TBlob TBlob2(vec2.data(), shape, 0);
-  std::vector<mxnet::TBlob> inblobs;
-  inblobs.push_back(TBlob1);
-  inblobs.push_back(TBlob2);
+  mxnet::NDArray array1(mxnet::TBlob(vec1.data(), shape, 1, 0), 0);
+  mxnet::NDArray array2(mxnet::TBlob(vec2.data(), shape, 1, 0), 0);
+  std::vector<mxnet::NDArray> inblobs;
+  inblobs.push_back(array1);
+  inblobs.push_back(array2);
 
   auto graph = std::make_shared<Graph>(Graph());
   auto backend = GetBackendFromContext(mxnet::Context::CPU());
@@ -119,16 +119,16 @@ TEST(NGRAPH_NNVM, copy_TBlobs) {
   /*                     ->get_vector<float>()); */
   std::vector<float> vec3{0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   std::vector<float> vec4{1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
-  mxnet::TBlob TBlob3(vec3.data(), shape, 0);
-  mxnet::TBlob TBlob4(vec4.data(), shape, 0);
-  std::vector<mxnet::TBlob> outblobs;
-  outblobs.push_back(TBlob3);
-  outblobs.push_back(TBlob4);
+  mxnet::NDArray array3(mxnet::TBlob(vec3.data(), shape, 1, 0), 0);
+  mxnet::NDArray array4(mxnet::TBlob(vec4.data(), shape, 1, 0), 0);
+  std::vector<mxnet::NDArray> outblobs;
+  outblobs.push_back(array3);
+  outblobs.push_back(array4);
 
   // test 1: kWriteTo - vec3 = vec1
   // test 2: kAddTo - vec4 += vec2
   std::vector<mxnet::OpReqType> req{mxnet::kWriteTo, mxnet::kAddTo};
-  result_to_TBlob(placeholders, req, outblobs);
+  result_to_NDArray(placeholders, req, outblobs);
   EXPECT_EQ(vec1, vec3);
   std::vector<float> vec4_plus_vec2{12, 13, 14, 15, 16, 17, 18, 19, 20, 11};
   EXPECT_EQ(vec4_plus_vec2, vec4);


### PR DESCRIPTION
## Description ##
Adds sparse storage type awareness and ndarray integration to ngraph_bridge

## Checklist ##
### Essentials ###
- [ ✅ ] Passed code style checking (`make lint`)
- [ ✅ ] Changes are complete (i.e. I finished coding on this PR)
- [ ✅ ] All changes have test coverage

### Changes ###
- [ ✅ ] Sparse storage type awareness
- [ ✅ ] NDArray interface integration

## Comments ##
- test_gluon.py:test_export unittest fails with minor accuracy error, same as prior to this PR
