### PR TITLE
Fixes NGRAPH-1030: segfault in train_cifar10.py

### DIFF
--- a/NGRAPH_README.md
+++ b/NGRAPH_README.md
@@ -172,12 +172,6 @@ The following models are known to run successfully in this release:
 * `example/image-classification/train_mnist.py`
 * `example/image-classification/train_cifar10.py`
 
-  *Note:* Due to limitations in the nGraph-enabled MXNet software, the
-  `train_cifar10.py` may run successfully only if the following environment variables
-  are set as indicated:
-    * `OMP_NUM_THREADS=16`
-    * `KMP_AFFINITY=granularity=fine,compact,1,0`
-
 Other models are under development are not guaranteed to run to completion or converge.
 This is a temporary limitation expected to be lifted in a future release.
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -28,7 +28,12 @@ if "--inplace" in sys.argv:
 else:
     from setuptools import setup
     from setuptools.extension import Extension
-    kwargs = {'install_requires': ['numpy<=1.13.3,>=1.8.2', 'requests==2.18.4', 'graphviz==0.8.1'], 'zip_safe': False}
+    kwargs = {'install_requires': [
+      'numpy<=1.13.3,>=1.8.2',
+      'requests==2.18.4',
+      'graphviz==0.8.1',
+      'psutil>=5.4.3',
+      ], 'zip_safe': False}
 from setuptools import find_packages
 
 with_cython = False


### PR DESCRIPTION
* Works around problem in which if `mxnet::engine::OpenMP::OpenmP()`
  calls `omp_set_num_threads(...)` then a segfault occurs in later.
  The workaround only addresses cases where `libmxnet.so` is accessed
  via our Python module.

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
