### PR TITLE
remove set -e in run_unit_test

### DIFF
--- a/docker/scripts/run-unit-tests.sh
+++ b/docker/scripts/run-unit-tests.sh
@@ -26,6 +26,3 @@ cd python && sudo -E pip install -e . && cd ../
 ## Unit tests test_operator.py 
 cmd="OMP_NUM_THREADS=4 pytest -s -n 2 tests/python/unittest/test_operator.py --verbose --capture=no --junit-xml=result_test_operator.xml --junit-prefix=result_test_operator"
 eval $cmd
-
-cmd="OMP_NUM_THREADS=4 pytest -s -n 2 tests/python/unittest/test_attr.py --verbose --capture=no --junit-xml=result_test_attr.xml --junit-prefix=result_test_attr"
-eval $cmd

--- a/docker/scripts/run-unit-tests.sh
+++ b/docker/scripts/run-unit-tests.sh
@@ -24,8 +24,8 @@ cd "$HOME/ng-mx"
 cd python && sudo -E pip install -e . && cd ../
 
 ## Unit tests test_operator.py 
-#cmd="OMP_NUM_THREADS=4 pytest -s -n 2 tests/python/unittest/test_operator.py --verbose --capture=no --junit-xml=result_test_operator.xml --junit-prefix=result_test_operator"
-#eval $cmd
+cmd="OMP_NUM_THREADS=4 pytest -s -n 2 tests/python/unittest/test_operator.py --verbose --capture=no --junit-xml=result_test_operator.xml --junit-prefix=result_test_operator"
+eval $cmd
 
 cmd="OMP_NUM_THREADS=4 pytest -s -n 2 tests/python/unittest/test_attr.py --verbose --capture=no --junit-xml=result_test_attr.xml --junit-prefix=result_test_attr"
 eval $cmd

--- a/docker/scripts/run-unit-tests.sh
+++ b/docker/scripts/run-unit-tests.sh
@@ -17,12 +17,15 @@
 #!/bin/bash
 #Author:  Lam Nguyen
 set -u
-set -e
+#set -e
 
 cd "$HOME/ng-mx"
 
 cd python && sudo -E pip install -e . && cd ../
 
 ## Unit tests test_operator.py 
-cmd="OMP_NUM_THREADS=4 pytest -s -n 2 tests/python/unittest/test_operator.py --verbose --capture=no --junit-xml=result_test_operator.xml --junit-prefix=result_test_operator"
+#cmd="OMP_NUM_THREADS=4 pytest -s -n 2 tests/python/unittest/test_operator.py --verbose --capture=no --junit-xml=result_test_operator.xml --junit-prefix=result_test_operator"
+#eval $cmd
+
+cmd="OMP_NUM_THREADS=4 pytest -s -n 2 tests/python/unittest/test_attr.py --verbose --capture=no --junit-xml=result_test_attr.xml --junit-prefix=result_test_attr"
 eval $cmd


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
