### PR TITLE
Towards NGRAPH-1191: only compile bprop graph when training

### DIFF
--- a/src/ngraph/ngraph_graph.h
+++ b/src/ngraph/ngraph_graph.h
@@ -229,7 +229,9 @@ class Graph : public Node {
   int num_outputs = 1;
   // nodes in this graph
   std::vector<NodePtr> nodes_;
-  // functions to execute this graph in ngraph
+  // functions to execute this graph in ngraph.
+  // Note: ngraph_backward[GraphExeMode::kInfer] should always be null, but we define it for
+  // consisteny.
   std::shared_ptr<ngraph::runtime::CallFrame>
       ngraph_forward[kGraphExeModeCount];
   std::shared_ptr<ngraph::runtime::CallFrame>

--- a/src/ngraph/ngraph_nnvm_ops.cc
+++ b/src/ngraph/ngraph_nnvm_ops.cc
@@ -109,6 +109,8 @@ void compute_backward(const mxnet::OpContext &ctx, std::shared_ptr<Graph> graph,
   auto results = make_ngraph_placeholders(outputs, backend, false);
   placeholders.insert(placeholders.end(), graph->cached_values[mode].begin(),
                       graph->cached_values[mode].end());
+
+  CHECK(graph->ngraph_backward[mode]);
   graph->ngraph_backward[mode]->call(results, placeholders);
   // reset the forward training compute flag to ensure backward always have
   // updated data from forward

--- a/src/ngraph/ngraph_sgcompiler.cc
+++ b/src/ngraph/ngraph_sgcompiler.cc
@@ -48,6 +48,24 @@ void dump_graph(std::shared_ptr<ngraph::Function> f) {
   file.close();
 }
 
+void CompileForward(std::shared_ptr<Graph> sub_graph,
+                            std::shared_ptr<ngraph::Function> f,
+                            GraphExeMode exe_mode) {
+  const int mode = static_cast<int>(exe_mode);
+
+  auto manager = GetManagerFromContext(sub_graph->context_);
+  auto backend = GetBackendFromContext(sub_graph->context_);
+
+  // Log the graph so Graph_* corresponds to Function_* in codgen
+  if (ngraph_log_graph) {
+    dump_graph(f);
+  }
+
+  sub_graph->ngraph_forward[mode] =
+      backend->make_call_frame(manager->compile(f));
+}
+
+
 void CompileForwardBackward(std::shared_ptr<Graph> sub_graph,
                             std::shared_ptr<ngraph::Function> f,
                             std::shared_ptr<ngraph::Function> bf,
@@ -213,23 +231,31 @@ void SGCompiler::CompileSubgraph(std::shared_ptr<Graph> sub_graph) {
   // initalize a placeholder order vector for this subgraph
   for (auto i : sub_graph->inputs_) placeholder_order_.push_back(i);
 
-  // compile all the ndoes in the graph
+  // compile all the nodes in the graph
   CompileNodes(sub_graph->nodes_.back(), sub_graph);
 
   auto f = MakeForwardFunction(sub_graph);
-  auto bf = MakeBackwardFunction(sub_graph, f);
 
-  if (ngraph_optimzation) {
-    OptimizeGraph(sub_graph, f, bf);
+  std::shared_ptr<ngraph::Function> maybe_bf;
+  if (exe_mode_ == GraphExeMode::kTrain) {
+    maybe_bf = MakeBackwardFunction(sub_graph, f);
+
+    // OptimizeGraph's real benefit comes from optimizing the fprop cache, so we only call it when
+    // we're in training mode...
+    if (ngraph_optimization) {
+      OptimizeGraph(sub_graph, f, maybe_bf);
+    }
   }
 
   if (ngraph_log_graph) {
     dump_graph(f);
-    dump_graph(bf);
+    if (maybe_bf) {
+      dump_graph(maybe_bf);
+    }
   }
 
   if (sub_graph->enable_fprop_cache && exe_mode_ == GraphExeMode::kTrain) {
-    auto fprop_cache = ngraph::cache_fprop(f, bf, {bf->get_parameters()[0]});
+    auto fprop_cache = ngraph::cache_fprop(f, maybe_bf, {maybe_bf->get_parameters()[0]});
 
     if (ngraph_log_graph) {
       dump_graph(fprop_cache.fprop);
@@ -245,11 +271,19 @@ void SGCompiler::CompileSubgraph(std::shared_ptr<Graph> sub_graph) {
                                             node->get_shape()));
     }
 
-  } else {
+    return;
+  }
+
+  if (exe_mode_ == GraphExeMode::kTrain) {
     ngraph::FpropCache fprop_cache;
     fprop_cache.node_param_map = std::make_shared<ngraph::NodeMap>();
-    CompileForwardBackward(sub_graph, f, bf, exe_mode_, fprop_cache);
+    CompileForwardBackward(sub_graph, f, maybe_bf, exe_mode_, fprop_cache);
+    return;
   }
+
+  CHECK(exe_mode_ == GraphExeMode::kInfer);
+  // No need to compile the backprop function if we're running in inference mode.
+  CompileForward(sub_graph, f, exe_mode_);
 }
 
 /**

--- a/src/ngraph/ngraph_utils.h
+++ b/src/ngraph/ngraph_utils.h
@@ -29,7 +29,7 @@ namespace ngraph_bridge {
 
 // enable ngraph gluon at runtime.
 const bool ngraph_gluon_enable = dmlc::GetEnv("MXNET_NGRAPH_GLUON", false);
-const bool ngraph_optimzation =
+const bool ngraph_optimization =
     dmlc::GetEnv("MXNET_NGRAPH_GRAPH_OPTIMIZATION", false);
 
 // logging


### PR DESCRIPTION
## Description ##
Stop trying to compile the ngraph backprop graph when mxnet's execution mode is "inference".  This avoids wasted computation time, and avoids the problem where the "inference" variant of nGraph's batchnorm operator does not support autodiff. 

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
Verified by running `train_cifar10.py` successfully (stopped after numerous batches trained on).

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
