### PR TITLE
Additional ngraph serializations.

### DIFF
--- a/src/ngraph/ngraph_nnvm_ops.cc
+++ b/src/ngraph/ngraph_nnvm_ops.cc
@@ -33,7 +33,7 @@
 namespace ngraph_bridge {
 
 #if MXNET_USE_CUDA
-#define NGRAPH_TRANSFORMERS {"cpu","gpu"}
+#define NGRAPH_TRANSFORMERS {"cpu", "gpu"}
 #else
 #define NGRAPH_TRANSFORMERS {"cpu"}
 #endif


### PR DESCRIPTION
## Description ##
Adds another serialization or two of mxnet's ngraph graphs, to facilitate debugging.

This is motivated by the fact that it's currently hard to visualize an ngraph graph that's undergone certain modifications by ngraph's optimization passes.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
