### PR TITLE
Fixes NGRAPH-1191 - BN refactor and inference

### DIFF
--- a/src/ngraph/ngraph_emitter.cc
+++ b/src/ngraph/ngraph_emitter.cc
@@ -124,7 +124,7 @@ NgraphNodePtr Emitter::ReduceAxes(
     const NodePtr& node,
     const std::function<NgraphNodePtr(const NgraphNodePtr&,
                                       const ngraph::AxisSet&)>& func) const {
-  auto input = checked_lookup(op_map_, node->inputs_[0]);
+  auto input = op_map_.at(node->inputs_[0]);
   return ReduceAxes(
       input, get_default(node, "axis", pyrange(input->get_shape().size())),
       get_default(node, "exclude", false), get_default(node, "keepdims", false),

--- a/src/ngraph/ngraph_emitter.h
+++ b/src/ngraph/ngraph_emitter.h
@@ -43,16 +43,20 @@ class Emitter {
   NgraphNodePtr CreateAutoBroadcast(const NodePtr& node);
   template <class op>
   NgraphNodePtr CreateScalarOp(const NodePtr& node);
+
+ public:
   // Factory function for reducing based on a reduction op function
-  NgraphNodePtr ReduceAxes(
+  static NgraphNodePtr ReduceAxes(
       const NgraphNodePtr& node, ngraph::AxisVector axes, bool exclude,
       bool keepdims,
       const std::function<NgraphNodePtr(const NgraphNodePtr&,
                                         const ngraph::AxisSet&)>& func);
+
+ protected:
   NgraphNodePtr ReduceAxes(
       const NodePtr& node,
       const std::function<NgraphNodePtr(const NgraphNodePtr&,
-                                        const ngraph::AxisSet&)>& func);
+                                        const ngraph::AxisSet&)>& func) const;
 
   // information on compiled objects
   std::map<NodePtr, NgraphNodePtr> op_map_;

--- a/src/ngraph/ngraph_utils.cc
+++ b/src/ngraph/ngraph_utils.cc
@@ -85,4 +85,98 @@ void dump_graph(std::shared_ptr<ngraph::Function> f, std::string src_loc,
   file.close();
 }
 
+bool has_vector_plus_axes_shape(const ngraph::Shape & s) {
+  if (s.size() < 1) {
+    return false;
+  }
+
+  bool already_found_big_axis = false;
+  for (size_t axis_span : s) {
+    if (axis_span == 0) {
+      return false;
+    }
+
+    const bool is_big_axis = (axis_span > 1);
+
+    if (is_big_axis) {
+      if (already_found_big_axis) {
+        return false;
+      } else {
+        already_found_big_axis = true;
+      }
+    }
+  }
+
+  return true;
+}
+
+ngraph::Shape get_vector_plus_axes_shape(
+    const size_t rank,
+    const size_t vector_axis,
+    const size_t vector_length) {
+  CHECK_GT(rank, 0);
+  CHECK_GT(rank, vector_axis);
+  CHECK_GT(vector_length, 0);
+
+  ngraph::Shape s(rank, 1);
+  s[vector_axis] = vector_length;
+
+  return s;
+}
+
+NgraphNodePtr ensure_vector_only_shape(
+    const NgraphNodePtr n) {
+  CHECK(n);
+  const ngraph::Shape & n_shape = n->get_shape();
+
+  const size_t n_rank = n_shape.size();
+
+  if (!has_vector_plus_axes_shape(n_shape)) {
+    std::ostringstream os;
+    os << "Tensor shape " << n_shape << " is not in vector-plus-axes form.";
+    throw os.str();
+  }
+
+  if (n_rank == 1) {
+    return n;
+  } else {
+    // We already know it's in vector-plus-axes form, so just count the number of elements.
+    const size_t vector_length = ngraph::shape_size(n_shape);
+
+    const ngraph::Shape output_shape{vector_length};
+    const ngraph::AxisVector permute_order = pyrange(n_rank);
+
+    return std::make_shared<ngraph::op::Reshape>(n, permute_order, output_shape);
+  }
+}
+
+NgraphNodePtr ensure_vector_plus_axes_shape(
+    const NgraphNodePtr n,
+    const size_t n_vector_axis,
+    const size_t output_rank,
+    const size_t output_vector_axis) {
+  CHECK(n);
+  const ngraph::Shape & n_shape = n->get_shape();
+  const size_t n_rank = n_shape.size();
+
+  CHECK(n_vector_axis < n_rank);
+  CHECK(n_rank <= output_rank);
+  CHECK(output_vector_axis < output_rank);
+
+  const size_t n_vector_length = n_shape[n_vector_axis];
+
+  const ngraph::Shape output_shape = get_vector_plus_axes_shape(
+      output_rank, output_vector_axis, n_vector_length);
+
+  if (n_shape == output_shape) {
+    return n;
+  } else {
+    const ngraph::AxisVector permute_order = pyrange(n_rank);
+    const NgraphNodePtr ng_reshaped =
+      std::make_shared<ngraph::op::Reshape>(n, permute_order, output_shape);
+    return ng_reshaped;
+  }
+}
+
+
 }  // namespace ngraph_bridge

--- a/src/ngraph/ngraph_utils.h
+++ b/src/ngraph/ngraph_utils.h
@@ -229,15 +229,6 @@ ngraph::AxisSet shape_to_axis_set(const ngraph::Shape& s);
 ngraph::AxisSet ngraph_remaining_axes(const NgraphNodePtr& n,
                                       const ngraph::AxisSet& a);
 
-/// A convenience method for looking up values in const std::map objects.
-template <typename MapType>
-typename MapType::mapped_type checked_lookup(
-    const MapType& m, const typename MapType::key_type& k) {
-  const auto iter = m.find(k);
-  CHECK(iter != m.end());
-  return iter->second;
-}
-
 template <typename T>
 std::ostream& container_to_debug_stream(
     std::ostream& os, const T& container, const std::string separator = ", ",
@@ -299,7 +290,6 @@ ngraph::Shape get_vector_plus_axes_shape(
 // If 'n' already meets those criteria, simply return 'n'.
 NgraphNodePtr ensure_vector_plus_axes_shape(
     const NgraphNodePtr n,
-    const size_t n_vector_axis,
     const size_t output_rank,
     const size_t output_vector_axis);
 

--- a/src/ngraph/ops/batchnorm.cc
+++ b/src/ngraph/ops/batchnorm.cc
@@ -1,0 +1,166 @@
+/*******************************************************************************
+* Copyright 2018 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "ops/batchnorm.h"
+
+#include <ngraph/op/get_output_element.hpp>
+
+#include "ngraph_utils.h"
+#include "ngraph_emitter.h"
+#include "ngraph_sgcompiler_utils.h"
+
+using std::make_shared;
+using ngraph::builder::make_with_numpy_broadcast;
+
+namespace ngraph_bridge {
+
+static NgraphNodePtr create_batchnorm_basic_computation_nodes(
+    const NgraphNodePtr& ng_mean, const NgraphNodePtr& ng_variance,
+    const NgraphNodePtr& ng_in_data, const NgraphNodePtr& ng_epsilon,
+    const NgraphNodePtr& ng_in_gamma_reshaped_or_null,
+    const NgraphNodePtr& ng_in_beta_reshaped) {
+  const NgraphNodePtr denom =
+      make_shared<ngraph::op::Sqrt>(ng_variance + ng_epsilon);
+
+  const NgraphNodePtr numerator =
+      make_with_numpy_broadcast<ngraph::op::Subtract>(ng_in_data, ng_mean);
+
+  const NgraphNodePtr result_simply_normalized =
+      make_with_numpy_broadcast<ngraph::op::Divide>(numerator, denom);
+
+  NgraphNodePtr result_maybe_with_gamma;
+  if (ng_in_gamma_reshaped_or_null) {
+    result_maybe_with_gamma = make_with_numpy_broadcast<ngraph::op::Multiply>(
+        result_simply_normalized, ng_in_gamma_reshaped_or_null);
+  } else {
+    result_maybe_with_gamma = result_simply_normalized;
+  }
+
+  return make_with_numpy_broadcast<ngraph::op::Add>(
+      result_maybe_with_gamma, ng_in_beta_reshaped);
+}
+
+std::tuple<NgraphNodePtr, NgraphNodePtr, NgraphNodePtr>
+create_batchnorm_training_without_ngraph_bn_op(
+    const float epsilon,
+    const NgraphNodePtr ng_maybe_gamma,
+    const NgraphNodePtr ng_beta,
+    const NgraphNodePtr ng_in_data,
+    const size_t channel_axis) {
+  const ngraph::Shape & batch_data_shape = ng_in_data->get_shape();
+  const size_t batch_data_rank = batch_data_shape.size();
+
+  const ngraph::element::Type et = ng_in_data->get_element_type();
+  CHECK(ng_beta->get_element_type() == et);
+
+  CHECK(channel_axis < batch_data_rank);
+  const size_t channel_axis_length = batch_data_shape[ channel_axis ];
+
+  const ngraph::Shape channel_vector_plus_axes_shape = get_vector_plus_axes_shape(
+      batch_data_rank, channel_axis, channel_axis_length);
+
+  NgraphNodePtr ng_normalized_batch;
+
+  const NgraphNodePtr ng_batch_means =
+    Emitter::ReduceAxes(ng_in_data, {channel_axis}, true, true, ngraph::builder::mean);
+
+  const NgraphNodePtr ng_batch_variances =
+    Emitter::ReduceAxes(ng_in_data, {channel_axis}, true, true,
+        [](const std::shared_ptr<ngraph::Node>& node,
+          const ngraph::AxisSet& axes) {
+        return ngraph::builder::variance(node, axes);
+        });
+
+  const NgraphNodePtr ng_epsilon_shaped = makeConstant(et, channel_vector_plus_axes_shape, epsilon);
+
+  const NgraphNodePtr ng_beta_shaped =
+    ensure_vector_plus_axes_shape(ng_beta, 0, batch_data_rank, channel_axis);
+
+  const NgraphNodePtr ng_gamma_shaped_or_null = ng_maybe_gamma
+    ? ensure_vector_plus_axes_shape(ng_maybe_gamma, 0, batch_data_rank, channel_axis)
+    : NgraphNodePtr{};
+
+  ng_normalized_batch = create_batchnorm_basic_computation_nodes(
+      ng_batch_means, ng_batch_variances, ng_in_data, ng_epsilon_shaped,
+      ng_gamma_shaped_or_null, ng_beta_shaped);
+
+  const NgraphNodePtr ng_batch_means_vector_shaped =
+    ensure_vector_only_shape(ng_batch_means);
+
+  const NgraphNodePtr ng_batch_variances_vector_shaped =
+    ensure_vector_only_shape(ng_batch_variances);
+
+  return std::tuple<NgraphNodePtr, NgraphNodePtr, NgraphNodePtr>{
+    ng_normalized_batch,
+    ng_batch_means_vector_shaped,
+    ng_batch_variances_vector_shaped};
+}
+
+NgraphNodePtr create_batchnorm_inference_without_ngraph_bn_op(
+    const float epsilon,
+    const NgraphNodePtr ng_maybe_gamma,
+    const NgraphNodePtr ng_beta,
+    const NgraphNodePtr ng_in_data,
+    const NgraphNodePtr ng_moving_mean,
+    const NgraphNodePtr ng_moving_var,
+    const size_t channel_axis) {
+  const ngraph::Shape & batch_data_shape = ng_in_data->get_shape();
+  const size_t batch_data_rank = batch_data_shape.size();
+
+  CHECK(channel_axis < batch_data_rank);
+  const size_t channel_axis_length = batch_data_shape[ channel_axis ];
+
+  const NgraphNodePtr ng_mean_shaped =
+    ensure_vector_plus_axes_shape(ng_moving_mean, 0, batch_data_rank, channel_axis);
+
+  const NgraphNodePtr ng_var_shaped =
+    ensure_vector_plus_axes_shape(ng_moving_var, 0, batch_data_rank, channel_axis);
+
+  const ngraph::Shape channel_vector_plus_axes_shape = get_vector_plus_axes_shape(
+      batch_data_rank, channel_axis, channel_axis_length);
+
+  const ngraph::element::Type et = ng_in_data->get_element_type();
+  CHECK(ng_beta->get_element_type() == et);
+
+  const NgraphNodePtr ng_epsilon_shaped = makeConstant(et, channel_vector_plus_axes_shape, epsilon);
+
+  const NgraphNodePtr denom = std::make_shared<ngraph::op::Sqrt>(ng_var_shaped + ng_epsilon_shaped);
+
+  const NgraphNodePtr numerator =
+    make_with_numpy_broadcast<ngraph::op::Subtract>(ng_in_data, ng_mean_shaped);
+
+  NgraphNodePtr result =
+    make_with_numpy_broadcast<ngraph::op::Divide>(numerator, denom);
+
+  if (ng_maybe_gamma) {
+    const NgraphNodePtr ng_gamma_shaped =
+      ensure_vector_plus_axes_shape(ng_maybe_gamma, 0, batch_data_rank, channel_axis);
+
+    const NgraphNodePtr ng_scale_by_gamma =
+      make_with_numpy_broadcast<ngraph::op::Multiply>(result, ng_gamma_shaped);
+
+    result = ng_scale_by_gamma;
+  }
+
+  const NgraphNodePtr ng_beta_shaped =
+    ensure_vector_plus_axes_shape(ng_beta, 0, batch_data_rank, channel_axis);
+
+  result = make_with_numpy_broadcast<ngraph::op::Add>(result, ng_beta_shaped);
+
+  return result;
+}
+
+}  // namespace ngraph_bridge

--- a/src/ngraph/ops/batchnorm.h
+++ b/src/ngraph/ops/batchnorm.h
@@ -1,0 +1,51 @@
+/*******************************************************************************
+* Copyright 2018 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef MXNET_NGRAPH_OPS_BATCHNORM_H_
+#define MXNET_NGRAPH_OPS_BATCHNORM_H_
+
+#include <tuple>
+
+#include "ngraph_emitter.h"
+
+namespace ngraph_bridge {
+
+// Create an subgraph of nGraph nodes that's functionally equivalent to nGraph's training-version
+// BatchNorm op, but which doesn't actually use that particular nGraph op.
+// This function exists as a crutch until nGraph's BatchNorm op is fully implemented.
+std::tuple<NgraphNodePtr, NgraphNodePtr, NgraphNodePtr>
+create_batchnorm_training_without_ngraph_bn_op(
+    const float epsilon,
+    const NgraphNodePtr ng_maybe_gamma,
+    const NgraphNodePtr ng_beta,
+    const NgraphNodePtr ng_in_data,
+    size_t channel_axis);
+
+// Create an subgraph of nGraph nodes that's functionally equivalent to nGraph's inference-version
+// BatchNorm op, but which doesn't actually use that particular nGraph op.
+// This function exists as a crutch until nGraph's BatchNorm op is fully implemented.
+NgraphNodePtr create_batchnorm_inference_without_ngraph_bn_op(
+    const float epsilon,
+    const NgraphNodePtr ng_maybe_gamma,
+    const NgraphNodePtr ng_beta,
+    const NgraphNodePtr ng_in_data,
+    const NgraphNodePtr ng_moving_mean,
+    const NgraphNodePtr ng_moving_var,
+    size_t channel_axis);
+
+}  // namespace ngraph_bridge
+
+#endif  // MXNET_NGRAPH_OPS_BATCHNORM_H_

--- a/src/ngraph/ops/batchnorm.h
+++ b/src/ngraph/ops/batchnorm.h
@@ -26,6 +26,8 @@ namespace ngraph_bridge {
 // Create an subgraph of nGraph nodes that's functionally equivalent to nGraph's training-version
 // BatchNorm op, but which doesn't actually use that particular nGraph op.
 // This function exists as a crutch until nGraph's BatchNorm op is fully implemented.
+//
+// All of the nGraph nodes created by this function support autodiff.
 std::tuple<NgraphNodePtr, NgraphNodePtr, NgraphNodePtr>
 create_batchnorm_training_without_ngraph_bn_op(
     const float epsilon,
@@ -37,6 +39,8 @@ create_batchnorm_training_without_ngraph_bn_op(
 // Create an subgraph of nGraph nodes that's functionally equivalent to nGraph's inference-version
 // BatchNorm op, but which doesn't actually use that particular nGraph op.
 // This function exists as a crutch until nGraph's BatchNorm op is fully implemented.
+//
+// All of the nGraph nodes created by this function support autodiff.
 NgraphNodePtr create_batchnorm_inference_without_ngraph_bn_op(
     const float epsilon,
     const NgraphNodePtr ng_maybe_gamma,


### PR DESCRIPTION
* Refactors emitter code for MXNet's Batchnorm operator.

* Refactored code handles traditional training and inference versions of
  the operator.

* No support currently for MXNet's hybrid-mode Batchnorm (like trainig
  mode, but the mean and variance are supplied by the caller rather than
  computed internally by the BN operation.) If such an operator is
  encountered, an error is thrown.

* In cases where nGraph is known to handle the Batchnorm operation
  with an efficient kernel, nGraph's BatchNorm operator is used.
  In all other cases batchnorm is computed using a collection of
  other nGraph operators.

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
