### PR TITLE
change get_backend_name to accept multi-context 

### DIFF
--- a/src/ngraph/ngraph_graph.h
+++ b/src/ngraph/ngraph_graph.h
@@ -153,13 +153,13 @@ static std::unordered_map<std::string,
     backends;
 
 inline std::string get_backend_name(const mxnet::Context &context) {
-  if (context == mxnet::Context::NNP()) {
+  if (context.dev_type == mxnet::Context::NNP().dev_type) {
     return "NNP";
 #if MXNET_USE_CUDA
-  } else if (context == mxnet::Context::GPU()) {
+  } else if (context.dev_type == mxnet::Context::GPU().dev_type) {
     return "GPU";
 #endif
-  } else if (context == mxnet::Context::CPU()) {
+  } else if (context.dev_type == mxnet::Context::CPU().dev_type) {
     return "CPU";
   } else {
     return "INTERPRETER";
@@ -169,11 +169,12 @@ inline std::string get_backend_name(const mxnet::Context &context) {
 inline std::shared_ptr<ngraph::runtime::Backend> GetBackendFromContext(
     const mxnet::Context &context) {
   auto backend_name = get_backend_name(context);
-  if (backends.count(backend_name) == 0) {
+  auto backend_key = backend_name + ":" + std::to_string(context.dev_id);
+  if (backends.count(backend_key) == 0) {
     auto backend = ngraph::runtime::Backend::create(backend_name);
-    backends[backend_name] = backend;
+    backends[backend_key] = backend;
   }
-  return backends[backend_name];
+  return backends[backend_key];
 }
 
 class OutputElement;


### PR DESCRIPTION
## Description ##
- change `get_backend_name` to return the right type even when the dev_id is not 0. e.g. 'cpu:1' was used to return 'interpreter' because of the dev_id is not 0. 
- uses `backend_key` instead of `backend_name` for the key of the unordered map. e.g. 'cpu:0'  
- needs to follow up on the `Backend::create(backend_name)` for transformers

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change