### PR TITLE
NGRAPH-1705 Use nGraph for inerence with gluon Hybridize

### DIFF
--- a/include/mxnet/imperative.h
+++ b/include/mxnet/imperative.h
@@ -142,6 +142,9 @@ class Imperative {
     nnvm::Graph fwd_graph_;
     nnvm::Graph grad_graph_;
     nnvm::Graph full_graph_;
+#if MXNET_USE_NGRAPH == 1
+    nnvm::Graph ngraph_fwd_graph_;
+#endif
     bool inlining_;
     std::vector<nnvm::NodeEntry> ograd_entries_;
     std::vector<bool> curr_grad_req_;

--- a/src/imperative/cached_op.cc
+++ b/src/imperative/cached_op.cc
@@ -227,8 +227,6 @@ nnvm::Graph Imperative::CachedOp::GetForwardGraph(
 #if MXNET_USE_NGRAPH == 1
   {
     ngraph_bridge::BindArgBase bind(num_inputs());
-    nnvm::Symbol symbol;
-    symbol.outputs = g.outputs;
     auto compiler = ngraph_bridge::Compiler(
         g, inputs[0]->ctx(), cached_shape_inputs, cached_dtype_inputs,
         cached_storage_type_inputs);

--- a/src/imperative/cached_op.cc
+++ b/src/imperative/cached_op.cc
@@ -218,14 +218,13 @@ nnvm::Graph Imperative::CachedOp::GetForwardGraph(
 
   } else if (g.attrs.count(recording ? "full_mem_plan" : "forward_mem_plan")) {
 #if MXNET_USE_NGRAPH == 1
-    return ngraph_fwd_graph_;
-#else
-    return g;
+    if (!recording) return ngraph_fwd_graph_;
 #endif
+    return g;
   }
 
 #if MXNET_USE_NGRAPH == 1
-  {
+  if (!recording) {
     ngraph_bridge::BindArgBase bind(num_inputs());
     auto compiler = ngraph_bridge::Compiler(
         g, inputs[0]->ctx(), cached_shape_inputs, cached_dtype_inputs,
@@ -251,8 +250,7 @@ nnvm::Graph Imperative::CachedOp::GetForwardGraph(
     }
 
     ngraph_fwd_graph_.attrs["forward_ref_count"] =
-        std::make_shared<dmlc::any>(std::move(ref_count));
-
+        std::make_shared<dmlc::any>(ref_count);
     g = ngraph_fwd_graph_;
   }
 #endif

--- a/src/imperative/cached_op.cc
+++ b/src/imperative/cached_op.cc
@@ -212,19 +212,22 @@ nnvm::Graph Imperative::CachedOp::GetForwardGraph(
   match &= CheckAndInferStorageType(&g, std::move(dev_mask),
                                     std::move(storage_type_inputs), true);
 
+#if MXNET_USE_NGRAPH == 1
+    if (!recording) {
+      match &= ngraph_fwd_graph_.attrs.count("forward_mem_plan");
+      g = ngraph_fwd_graph_;
+    };
+#endif
+
   if (!match) {
     g.attrs.erase("forward_mem_plan");
     g.attrs.erase("full_mem_plan");
-
   } else if (g.attrs.count(recording ? "full_mem_plan" : "forward_mem_plan")) {
-#if MXNET_USE_NGRAPH == 1
-    if (!recording) return ngraph_fwd_graph_;
-#endif
     return g;
   }
 
 #if MXNET_USE_NGRAPH == 1
-  if (!recording) {
+  if (!recording) {  
     ngraph_bridge::BindArgBase bind(num_inputs());
     auto compiler = ngraph_bridge::Compiler(
         g, inputs[0]->ctx(), cached_shape_inputs, cached_dtype_inputs,
@@ -251,7 +254,6 @@ nnvm::Graph Imperative::CachedOp::GetForwardGraph(
 
     ngraph_fwd_graph_.attrs["forward_ref_count"] =
         std::make_shared<dmlc::any>(ref_count);
-    g = ngraph_fwd_graph_;
   }
 #endif
 

--- a/src/ngraph/ngraph_compiler.cc
+++ b/src/ngraph/ngraph_compiler.cc
@@ -115,8 +115,9 @@ Compiler::Compiler(const mxnet::Context& context)
 
 // Compiler initialization for gluon hybrid
 Compiler::Compiler(const nnvm::Graph& graph, const mxnet::Context& context,
-                   const std::vector<nnvm::TShape> shapes,
-                   const std::vector<int> dtypes, const std::vector<int> stypes)
+                   const std::vector<nnvm::TShape>& shapes,
+                   const std::vector<int>& dtypes,
+                   const std::vector<int>& stypes)
     : ngraph_("ngraph_" + randomString(6), context),
       shapes_(shapes),
       dtypes_(dtypes),

--- a/src/ngraph/ngraph_compiler.h
+++ b/src/ngraph/ngraph_compiler.h
@@ -188,8 +188,8 @@ class Compiler {
   Compiler(const mxnet::Context& context);
   // Constructor for use with gluon hybridize
   Compiler(const nnvm::Graph& graph, const mxnet::Context& context,
-           const std::vector<nnvm::TShape> shapes,
-           const std::vector<int> dtypes, const std::vector<int> stypes);
+           const std::vector<nnvm::TShape>& shapes,
+           const std::vector<int>& dtypes, const std::vector<int>& stypes);
   // Compile returns the compiled graph
   nnvm::Graph Compile();
   // parse the nnvm graph into an intermediate represenation

--- a/src/ngraph/ngraph_compiler.h
+++ b/src/ngraph/ngraph_compiler.h
@@ -186,6 +186,10 @@ class Compiler {
            const mxnet::Context& context);
   // Construct base compiler object with context only
   Compiler(const mxnet::Context& context);
+  // Constructor for use with gluon hybridize
+  Compiler(const nnvm::Graph& graph, const mxnet::Context& context,
+           const std::vector<nnvm::TShape> shapes,
+           const std::vector<int> dtypes, const std::vector<int> stypes);
   // Compile returns the compiled graph
   nnvm::Graph Compile();
   // parse the nnvm graph into an intermediate represenation
@@ -242,6 +246,8 @@ class Compiler {
   void Infer(const BindArg* bind);
   // infer nnvm::Graph shape and type for simple bind case
   void Infer(const SimpleBindArg* simplebind);
+  // infer nnvm::Graph shape and type for simple bind case
+  void InferGraphProperties();
 
   // inferred nnvm::Graph shape
   nnvm::ShapeVector shapes_;

--- a/src/ngraph/ngraph_compiler.h
+++ b/src/ngraph/ngraph_compiler.h
@@ -246,8 +246,6 @@ class Compiler {
   void Infer(const BindArg* bind);
   // infer nnvm::Graph shape and type for simple bind case
   void Infer(const SimpleBindArg* simplebind);
-  // infer nnvm::Graph shape and type for simple bind case
-  void InferGraphProperties();
 
   // inferred nnvm::Graph shape
   nnvm::ShapeVector shapes_;


### PR DESCRIPTION
## Description ##
There's code copy here from the rest of imperative, not sure if I want to refactor cached_op.cc to remove it.

Runs the forward pass of gluon hybridize ops through nGraph. Backward will be another PR.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
