### PR TITLE
NGRAPH-1177 enable other ngraph imperative kernels for Gluon

### DIFF
--- a/src/ngraph/ngraph_imperative.cc
+++ b/src/ngraph/ngraph_imperative.cc
@@ -110,6 +110,8 @@ bool compute_forward_imperative(const nnvm::NodeAttrs &attrs,
       }
     }
   }
+  // op_ng can be null if sgcompiler could not create ngraph IR
+  // we fallback to mxnet kernel in this case
   if (op_ng && op_ng->ngraph_forward[mode]) {
     compute_forward(ctx, op_ng, inputs, req, outputs);
 

--- a/src/ngraph/ngraph_imperative.cc
+++ b/src/ngraph/ngraph_imperative.cc
@@ -169,7 +169,8 @@ void InitImperativeOnce() {
             }
           },
           11);
-    } else if (fallbackx_fn) {
+    }
+    if (fallbackx_fn) {
       op.set_attr<mxnet::FComputeEx>(
           "FComputeEx<cpu>",
           [fallbackx_fn](const nnvm::NodeAttrs &attrs,
@@ -183,7 +184,8 @@ void InitImperativeOnce() {
             }
           },
           11);
-    } else if (fallback_fn) {
+    }
+    if (fallback_fn) {
       op.set_attr<mxnet::FCompute>(
           "FCompute<cpu>",
           [fallback_fn](const nnvm::NodeAttrs &attrs,
@@ -201,11 +203,11 @@ void InitImperativeOnce() {
             }
           },
           11);
-    } else {
-      if (ngraph_log_verbose_detail) {
+    }
+    if (ngraph_log_verbose_detail) {
+      if (!fallback_nd && !fallbackx_fn && !fallback_fn)
         std::cout << "NGRAPH IMPERATIVE: not implemented -> " << op_name
                   << std::endl;
-      }
     }
   }
 }

--- a/tests/python/ngraph/test_gluon.py
+++ b/tests/python/ngraph/test_gluon.py
@@ -90,7 +90,7 @@ def test_gluon_hybridize():
 
 def test_ngraph_imperative_gluon_convolution():
     """
-    This test will convolution op with ngrap involving mkldnn layout
+    This will test Gluon convolution op with ngraph imperative involving mkldnn layout
     """
 
     ctx = mx.cpu()

--- a/tests/python/ngraph/test_gluon.py
+++ b/tests/python/ngraph/test_gluon.py
@@ -13,15 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #*******************************************************************************
+"""
+ngraph-mxnet imperative gluon python unittests
+"""
 
 from __future__ import print_function
-import mxnet as mx
 import numpy as np
+import mxnet as mx
 from mxnet import gluon
 from mxnet.test_utils import assert_almost_equal
 
 
 class Net(gluon.Block):
+    """
+    sample gluon net
+    """
     def __init__(self, **kwargs):
         super(Net, self).__init__(**kwargs)
 
@@ -30,6 +36,9 @@ class Net(gluon.Block):
 
 
 class NetHybrid(gluon.HybridBlock):
+    """
+    sample gluon hybrid net
+    """
     def __init__(self, **kwargs):
         super(NetHybrid, self).__init__(**kwargs)
 
@@ -40,6 +49,9 @@ class NetHybrid(gluon.HybridBlock):
 
 
 def test_gluon_basic():
+    """
+    simple gluon test
+    """
     net = Net()
     a = mx.nd.array([1, 2])
     b = mx.nd.array([2, 3])
@@ -49,6 +61,9 @@ def test_gluon_basic():
 
 
 def test_gluon_hybrid():
+    """
+    simple gluon hybrid test
+    """
     net = NetHybrid()
     a = mx.nd.array([1, 2])
     b = mx.nd.array([2, 3])
@@ -58,6 +73,9 @@ def test_gluon_hybrid():
 
 
 def test_gluon_hybridize():
+    """
+    simple gluon hybridize test
+    """
     net = NetHybrid()
     a = mx.nd.array([1, 2])
     b = mx.nd.array([2, 3])
@@ -69,6 +87,22 @@ def test_gluon_hybridize():
     # compute forward after hybridize
     z = net(a, b)
     assert_almost_equal(z.asnumpy(), y.asnumpy(), rtol=1e-3, atol=1e-6)
+
+def test_ngraph_imperative_gluon_convolution():
+    """
+    This test will convolution op with ngrap involving mkldnn layout
+    """
+
+    ctx = mx.cpu()
+    net = gluon.nn.HybridSequential()
+    with net.name_scope():
+        net.add(gluon.nn.Conv2D(channels=32, kernel_size=3, activation=None))
+    net.collect_params().initialize(ctx=ctx)
+    x = mx.nd.array(np.ones([32, 3, 224, 224]), ctx)
+    y = net(x)
+
+    # trigger computation on ndarray slice
+    assert_almost_equal(y[0].asnumpy()[0, 0, 0], 0.3376348)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description ##
enable other ngraph imperative kernels for Gluon

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
