### PR TITLE
fix FC for gluon and resolve gluon optimizer unittests

### DIFF
--- a/src/ngraph/ngraph_emitter.cc
+++ b/src/ngraph/ngraph_emitter.cc
@@ -888,6 +888,13 @@ void Emitter::CreateLayerOps() {
 
     if (!no_bias) {
       auto beta = op_map_[node->inputs_[2]];
+      auto shape = beta->get_shape();
+      if (flatten && shape.size() > 1) {
+        beta = std::make_shared<ngraph::op::Reshape>(
+            beta, pyrange(shape.size()),
+            ngraph::Shape{std::accumulate(shape.begin(), shape.end(), 1ul,
+                                          std::multiplies<size_t>())});
+      }
       dot = ngraph::builder::make_with_numpy_broadcast<ngraph::op::Add>(dot,
                                                                         beta);
     }

--- a/src/ngraph/ngraph_imperative.h
+++ b/src/ngraph/ngraph_imperative.h
@@ -54,7 +54,8 @@ class NGImperative : public Compiler {
                                                            "SliceChannel"};
 
     static std::unordered_set<std::string> skip_imperative{
-        "expand_dims", "_copy", "_zeros", "zeros_like", "BatchNorm"};
+        "expand_dims", "_copy",     "_zeros",
+        "zeros_like",  "BatchNorm", "_mul_scalar"};
 
     if (skip_imperative.count(op_name)) return false;
 


### PR DESCRIPTION
## Description ##
fix FC for gluon and resolve gluon optimizer unittests

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
