### PR TITLE
NGRAPH-1790 Add SequenceReverse op support

### DIFF
--- a/src/ngraph/ngraph_emitter.cc
+++ b/src/ngraph/ngraph_emitter.cc
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include <ngraph/op/get_output_element.hpp>
+#include <ngraph/op/reverse_sequence.hpp>
 #include "ngraph_sgcompiler_utils.h"
 #include "ops/batchnorm.h"
 
@@ -1260,6 +1261,20 @@ void Emitter::CreateLayerOps() {
     auto mul_op = std::make_shared<ngraph::op::Multiply>(avg_pool_op, coeff_op);
 
     return mul_op;
+  };
+  ngraph_op_funcs_["SequenceReverse"] = [this](const NodePtr& node) -> NgraphNodePtr {
+    auto data = op_map_[node->inputs_[0]];
+    auto sequence_length = op_map_[node->inputs_[1]];
+    bool use_sequence_length = get_default(node, "use_sequence_length", false);
+    int axis = get_default(node, "axis", 0);
+    NgraphNodePtr seq_rev{nullptr};
+    if (use_sequence_length) {
+      seq_rev = std::make_shared<ngraph::op::ReverseSequence>(data, sequence_length, 1, axis);
+    }
+    else {
+      seq_rev = std::make_shared<ngraph::op::ReverseSequence>(data, NgraphNodePtr{nullptr}, 1, axis);
+    }
+    return seq_rev;
   };
 }
 

--- a/src/ngraph/ngraph_emitter.cc
+++ b/src/ngraph/ngraph_emitter.cc
@@ -1268,17 +1268,14 @@ void Emitter::CreateLayerOps() {
     bool use_sequence_length = get_default(node, "use_sequence_length", false);
     int seq_axis = get_default(node, "axis", 0);
     const int batch_axis = 1;
-    NgraphNodePtr sequence_length{nullptr};
     if (use_sequence_length) {
-      sequence_length = op_map_[node->inputs_[1]];
+      NgraphNodePtr sequence_length = op_map_[node->inputs_[1]];
+      return std::make_shared<ngraph::op::ReverseSequence>(
+          data, sequence_length, batch_axis, seq_axis);
     } else {
-      const ngraph::Shape& data_shape = data->get_shape();
-      sequence_length = makeConstant(data->get_element_type(),
-                                     ngraph::Shape{data_shape.at(batch_axis)},
-                                     std::to_string(data_shape.at(seq_axis)));
+      return std::make_shared<ngraph::op::Reverse>(data,
+                                                   ngraph::AxisSet{seq_axis});
     }
-    return std::make_shared<ngraph::op::ReverseSequence>(data, sequence_length,
-                                                         batch_axis, seq_axis);
   };
 }
 

--- a/src/ngraph/ngraph_emitter.cc
+++ b/src/ngraph/ngraph_emitter.cc
@@ -1265,16 +1265,17 @@ void Emitter::CreateLayerOps() {
   ngraph_op_funcs_["SequenceReverse"] =
       [this](const NodePtr& node) -> NgraphNodePtr {
     auto data = op_map_[node->inputs_[0]];
-    bool use_sequence_length = get_default(node, "use_sequence_length", false);
-    int seq_axis = get_default(node, "axis", 0);
-    const int batch_axis = 1;
+    const bool use_sequence_length =
+        get_default(node, "use_sequence_length", false);
+    const int seq_axis = get_default(node, "axis", 0);
     if (use_sequence_length) {
+      const int batch_axis = 1;
       NgraphNodePtr sequence_length = op_map_[node->inputs_[1]];
       return std::make_shared<ngraph::op::ReverseSequence>(
           data, sequence_length, batch_axis, seq_axis);
     } else {
-      return std::make_shared<ngraph::op::Reverse>(data,
-                                                   ngraph::AxisSet{seq_axis});
+      return std::make_shared<ngraph::op::Reverse>(
+          data, ngraph::AxisSet{static_cast<size_t>(seq_axis)});
     }
   };
 }


### PR DESCRIPTION
## Description ##
Added sequence reverse op support to the bridge.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] SequenceReverse op added and passes test_operator.py unit tests.

## Comments ##
