### PR TITLE
Adds logging detail for unsupported ngraph ops.

### DIFF
--- a/src/ngraph/ngraph_compiler.cc
+++ b/src/ngraph/ngraph_compiler.cc
@@ -400,7 +400,7 @@ void Compiler::DeepCopy(const nnvm::Graph& graph) {
 // Check nodes in NGraph
 void Compiler::CheckInNgraph() {
   std::unordered_set<std::string> unsupported_op_names;
-  for (auto node : ngraph_.nodes_) {
+  for (const std::shared_ptr<ngraph_bridge::Node>& node : ngraph_.nodes_) {
     // The bridge code only has nGraph emitters for kOp-type nodes.
     if (node->type_ == NodeType::kOp) {
       if (compiler_.ngraph_op_funcs_.count(node->operation_)) {
@@ -434,8 +434,17 @@ void Compiler::CheckInNgraph() {
             }
           }
         }
-      } else if (ngraph_log_verbose()) {
-        unsupported_op_names.insert(node->operation_);
+      } else {
+        if (ngraph_log_verbose()) {
+          unsupported_op_names.insert(node->operation_);
+        }
+
+        if (ngraph_log_verbose_detail()) {
+          std::cout << "NGRAPH_BRIDGE: Unsupported Op instance (verbose):"
+                    << std::endl;
+          node->printOpDetails(std::cout);
+          std::cout << std::endl;
+        }
       }
     }
   }

--- a/src/ngraph/ngraph_graph.cc
+++ b/src/ngraph/ngraph_graph.cc
@@ -435,4 +435,18 @@ void CollapseSubgraph(Graph* graph, int subgraph_num) {
   }
 }
 
+void Node::printOpDetails(std::ostream& os) {
+  using namespace std;
+  // The set of fields printed can be altered according to the developer's
+  // debugging needs.
+  const string indent{"  "};
+
+  os << "name_ = '" << name_ << "'" << endl;
+
+  os << "orig_node_->attrs.dict:" << endl;
+  for (const auto& kv : orig_node_->attrs.dict) {
+    os << indent << kv.first << " = '" << kv.second << "'" << endl;
+  }
+}
+
 }  // namespace ngraph_bridge

--- a/src/ngraph/ngraph_graph.h
+++ b/src/ngraph/ngraph_graph.h
@@ -95,6 +95,9 @@ class Node {
 
   std::string operation_ = "";
   int subgraph_ = 0;
+
+  /// For debugging and logging.
+  virtual void printOpDetails(std::ostream &os);
 };
 
 // Class to store Variables


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
