### PR TITLE
add smooth_l1 op to ngraph emitter

### DIFF
--- a/src/ngraph/ngraph_emitter.cc
+++ b/src/ngraph/ngraph_emitter.cc
@@ -721,6 +721,8 @@ void Emitter::CreateBinaryOps() {
 
     // 0.5 * (sigma * x) ^ 2
     auto result_input_sq = half * input * input * sigma_sq;
+
+    // cant use abs as we need -input depending on input < -inv_sigma_sq
     // x - 0.5 / (sigma ^ 2)
     auto result_input_gt = input - half_inv_sigma_sq;
     // -x - 0.5 / (sigma ^ 2)

--- a/src/ngraph/ngraph_emitter.cc
+++ b/src/ngraph/ngraph_emitter.cc
@@ -695,6 +695,42 @@ void Emitter::CreateBinaryOps() {
     return cast_result(CreateAutoBroadcast<ngraph::op::LessEq>(node),
                        getType(node->dtype_));
   };
+  ngraph_op_funcs_["smooth_l1"] = [this](const NodePtr& node) {
+    /* Smooth L1 Loss is a loss specific for R-CNN franchise training
+     * Smooth L1 Loss function:
+     * f(x) = 0.5 * (sigma * x) ^ 2,     |x| < 1 / sigma^2
+     *      = |x| - 0.5 / sigma / sigma, otherwise
+     * When sigma = 1, it is equivalent to the Huber loss, evaluated at
+     * delta = 1.
+     * smooth_l1_loss = w_out * f(w_in * x)
+     * with w_in, w_out provided by input_data.
+     */
+    auto input = op_map_[node->inputs_[0]];
+    auto sigma =
+        makeConstant(node, get_default(node, "scalar", std::string("0")));
+    auto sigma_sq = sigma * sigma;
+    auto inv_sigma_sq = std::make_shared<ngraph::op::Divide>(
+        makeConstant(node, "1.0"), sigma_sq);
+
+    // check if input is greater than inv_sigma_sq
+    auto is_input_gt_sigma =
+        std::make_shared<ngraph::op::Greater>(input, inv_sigma_sq);
+
+    // f(x) = 0.5 * (sigma * x) ^ 2
+    auto result_input_sq = makeConstant(node, "0.5") * input * input * sigma_sq;
+    // f(x) = x - 0.5 / sigma / sigma
+    auto result_input_gt = input - makeConstant(node, "0.5") * inv_sigma_sq;
+    // f(x) = -x - 0.5 / sigma / sigma
+    auto result_input_lt = -input - makeConstant(node, "0.5") * inv_sigma_sq;
+
+    // select result according to formula
+    auto is_input_lt = std::make_shared<ngraph::op::Less>(input, -inv_sigma_sq);
+    auto result_input = std::make_shared<ngraph::op::Select>(
+        is_input_lt, result_input_lt, result_input_sq);
+
+    return std::make_shared<ngraph::op::Select>(is_input_gt_sigma,
+                                                result_input_gt, result_input);
+  };
   ngraph_op_funcs_["SequenceMask"] = [this](const NodePtr& node) {
     auto data = op_map_[node->inputs_[0]];
 


### PR DESCRIPTION
## Description ##
add smooth_l1 op to ngraph emitter

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
