### PR TITLE
Add MakeLoss Op to ngraph emitter

### DIFF
--- a/src/ngraph/ngraph_compiler.h
+++ b/src/ngraph/ngraph_compiler.h
@@ -165,7 +165,8 @@ static std::unordered_set<std::string> ops_no_head_grad{
     "_greater_scalar",
     "_greater_equal_scalar",
     "_lesser_scalar",
-    "_lesser_equal_scalar"};
+    "_lesser_equal_scalar",
+    "MakeLoss"};
 
 // Utility function for replacing operation names
 // based on the dict above

--- a/src/ngraph/ngraph_emitter.cc
+++ b/src/ngraph/ngraph_emitter.cc
@@ -1455,9 +1455,12 @@ void Emitter::CreateLossOps() {
 
     NgraphNodePtr grad;
     if (norm == "valid") {
+      throw std::runtime_error(std::string("NGRAPH_BRIDGE: MakeLoss ") +
+                               "normalization not yet tested " +
+                               "in NGraph, please test with this script.");
     } else if (norm == "batch") {
-      grad =
-          grad_scale / makeConstant(node, std::to_string(input->get_shape()[0]));
+      grad = grad_scale /
+             makeConstant(node, std::to_string(input->get_shape()[0]));
     } else {
       grad = grad_scale;
     }


### PR DESCRIPTION
## Description ##
Add MakeLoss Op to ngraph emitter

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
