### PR TITLE
add BlockGrad op to ngraph emitter

### DIFF
--- a/src/ngraph/ngraph_compiler.h
+++ b/src/ngraph/ngraph_compiler.h
@@ -143,6 +143,7 @@ static std::unordered_map<std::string, std::string> nameswitch({
     {"Cast", "cast"},
     {"sum_axis", "sum"},
     {"SliceChannel", "split"},
+    {"BlockGrad", "stop_gradient"},
 });
 
 // MxNet OPs that do not have gradient should work when head-gradient is not
@@ -166,7 +167,8 @@ static std::unordered_set<std::string> ops_no_head_grad{
     "_greater_equal_scalar",
     "_lesser_scalar",
     "_lesser_equal_scalar",
-    "MakeLoss"};
+    "MakeLoss",
+    "stop_gradient"};
 
 // Utility function for replacing operation names
 // based on the dict above

--- a/src/ngraph/ngraph_emitter.cc
+++ b/src/ngraph/ngraph_emitter.cc
@@ -397,7 +397,7 @@ void Emitter::CreateUnaryOps() {
                                                  getType(node->dtype_));
   };
   ngraph_op_funcs_["stop_gradient"] = [this](const NodePtr& node) {
-    return op_map_[node->inputs_[0]];
+    return std::make_shared<ngraph::op::StopGradient>(op_map_[node->inputs_[0]]);
   };
 
   //----------------------------- Reduce Ops ----------------------------//
@@ -1564,10 +1564,6 @@ void Emitter::CreateLossOps() {
     }
 
     return grad;
-  };
-  loss_op_backward_funcs_["stop_gradient"] = [this](
-      const NodePtr& node, const NgraphNodePtr& adjoint) {
-    return makeConstant(node->inputs_[0], "0");
   };
 }
 

--- a/src/ngraph/ngraph_emitter.cc
+++ b/src/ngraph/ngraph_emitter.cc
@@ -396,6 +396,9 @@ void Emitter::CreateUnaryOps() {
     return std::make_shared<ngraph::op::Convert>(op_map_[node->inputs_[0]],
                                                  getType(node->dtype_));
   };
+  ngraph_op_funcs_["stop_gradient"] = [this](const NodePtr& node) {
+    return op_map_[node->inputs_[0]];
+  };
 
   //----------------------------- Reduce Ops ----------------------------//
   ngraph_op_funcs_["norm"] = [this](const NodePtr& node) {
@@ -1561,6 +1564,10 @@ void Emitter::CreateLossOps() {
     }
 
     return grad;
+  };
+  loss_op_backward_funcs_["stop_gradient"] = [this](
+      const NodePtr& node, const NgraphNodePtr& adjoint) {
+    return makeConstant(node->inputs_[0], "0");
   };
 }
 


### PR DESCRIPTION
## Description ##
add BlockGrad op to ngraph emitter

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
