### PR TITLE
add LinearRegressionOutput op to ngraph emitter

### DIFF
--- a/src/ngraph/ngraph_compiler.h
+++ b/src/ngraph/ngraph_compiler.h
@@ -150,17 +150,23 @@ static std::unordered_map<std::string, std::string> nameswitch({
 // passed. Below OPs in ngrap-bridge fit this criteria.
 static std::unordered_set<std::string> ops_no_head_grad{
     "_equal",
-    "_not_equal",
+    "_equal_scalar",
     "_greater",
+    "_greater_scalar",
     "_greater_equal",
+    "_greater_equal_scalar",
     "_lesser",
+    "_lesser_scalar",
     "_lesser_equal",
+    "_lesser_equal_scalar",
+    "_not_equal",
+    "_not_equal_scalar",
     "broadcast_equal",
-    "broadcast_not_equal",
     "broadcast_greater",
     "broadcast_greater_equal",
     "broadcast_lesser",
     "broadcast_lesser_equal",
+<<<<<<< HEAD
     "_equal_scalar",
     "_not_equal_scalar",
     "_greater_scalar",
@@ -175,9 +181,26 @@ static std::unordered_set<std::string> ops_no_head_grad{
     "MakeLoss"};
 =======
     "MakeLoss",
+||||||| merged common ancestors
+    "_equal_scalar",
+    "_not_equal_scalar",
+    "_greater_scalar",
+    "_greater_equal_scalar",
+    "_lesser_scalar",
+    "MakeLoss",
+=======
+    "broadcast_not_equal",
+>>>>>>> sort the list for ops_no_head_grad
     "LinearRegressionOutput",
+<<<<<<< HEAD
     "_lesser_equal_scalar"};
 >>>>>>> add LinearRegressionOutput op to ngraph emitter
+||||||| merged common ancestors
+    "_lesser_equal_scalar"};
+=======
+    "MakeLoss",
+};
+>>>>>>> sort the list for ops_no_head_grad
 
 // Utility function for replacing operation names
 // based on the dict above

--- a/src/ngraph/ngraph_compiler.h
+++ b/src/ngraph/ngraph_compiler.h
@@ -166,9 +166,18 @@ static std::unordered_set<std::string> ops_no_head_grad{
     "_greater_scalar",
     "_greater_equal_scalar",
     "_lesser_scalar",
+<<<<<<< HEAD
     "_lesser_equal_scalar",
     "MakeLoss",
     "stop_gradient"};
+||||||| merged common ancestors
+    "_lesser_equal_scalar",
+    "MakeLoss"};
+=======
+    "MakeLoss",
+    "LinearRegressionOutput",
+    "_lesser_equal_scalar"};
+>>>>>>> add LinearRegressionOutput op to ngraph emitter
 
 // Utility function for replacing operation names
 // based on the dict above

--- a/src/ngraph/ngraph_compiler.h
+++ b/src/ngraph/ngraph_compiler.h
@@ -166,39 +166,10 @@ static std::unordered_set<std::string> ops_no_head_grad{
     "broadcast_greater_equal",
     "broadcast_lesser",
     "broadcast_lesser_equal",
-<<<<<<< HEAD
-    "_equal_scalar",
-    "_not_equal_scalar",
-    "_greater_scalar",
-    "_greater_equal_scalar",
-    "_lesser_scalar",
-<<<<<<< HEAD
-    "_lesser_equal_scalar",
-    "MakeLoss",
-    "stop_gradient"};
-||||||| merged common ancestors
-    "_lesser_equal_scalar",
-    "MakeLoss"};
-=======
-    "MakeLoss",
-||||||| merged common ancestors
-    "_equal_scalar",
-    "_not_equal_scalar",
-    "_greater_scalar",
-    "_greater_equal_scalar",
-    "_lesser_scalar",
-    "MakeLoss",
-=======
     "broadcast_not_equal",
->>>>>>> sort the list for ops_no_head_grad
     "LinearRegressionOutput",
-<<<<<<< HEAD
-    "_lesser_equal_scalar"};
->>>>>>> add LinearRegressionOutput op to ngraph emitter
-||||||| merged common ancestors
-    "_lesser_equal_scalar"};
-=======
     "MakeLoss",
+    "stop_gradient",
 };
 >>>>>>> sort the list for ops_no_head_grad
 

--- a/src/ngraph/ngraph_compiler.h
+++ b/src/ngraph/ngraph_compiler.h
@@ -171,7 +171,6 @@ static std::unordered_set<std::string> ops_no_head_grad{
     "MakeLoss",
     "stop_gradient",
 };
->>>>>>> sort the list for ops_no_head_grad
 
 // Utility function for replacing operation names
 // based on the dict above

--- a/src/ngraph/ngraph_emitter.cc
+++ b/src/ngraph/ngraph_emitter.cc
@@ -1445,6 +1445,9 @@ void Emitter::CreateLayerOps() {
     // MakeLoss forward returns copy/identity
     return op_map_[node->inputs_[0]];
   };
+  ngraph_op_funcs_["LinearRegressionOutput"] = [this](const NodePtr& node) {
+    return op_map_[node->inputs_[0]];
+  };
 }
 
 void Emitter::CreateLossOps() {
@@ -1564,6 +1567,16 @@ void Emitter::CreateLossOps() {
     }
 
     return grad;
+  };
+  loss_op_backward_funcs_["LinearRegressionOutput"] = [this](
+      const NodePtr& node, const NgraphNodePtr& adjoint) {
+    auto label = op_map_[node->inputs_[0]];
+    auto data = op_map_[node->inputs_[1]];
+    auto grad_scale =
+        makeConstant(node, get_default(node, "grad_scale", std::string("1.0")));
+    auto num_output = makeConstant(
+        node, std::to_string(node->shape_.Size() / node->shape_[0]));
+    return (label - data) * grad_scale / num_output;
   };
 }
 


### PR DESCRIPTION
## Description ##
add LinearRegressionOutput op to ngraph emitter

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
