### PR TITLE
fixed build error when USE_NGRAPH is not set.

### DIFF
--- a/src/c_api/c_api_profile.cc
+++ b/src/c_api/c_api_profile.cc
@@ -32,7 +32,9 @@
 #include <fstream>
 #include <stack>
 #include "./c_api_common.h"
+#if MXNET_USE_NGRAPH == 1
 #include "../ngraph/ngraph_stats.h"
+#endif
 #include "../profiler/profiler.h"
 
 namespace mxnet {
@@ -512,6 +514,7 @@ int MXProfileSetMarker(ProfileHandle domain,
  */
 int MXDumpNGraphProfile(const char* file_name) {
   API_BEGIN();
+#if MXNET_USE_NGRAPH == 1
     if (file_name != nullptr && strlen(file_name) > 0) {
       std::ofstream file_out;
       file_out.open(file_name);
@@ -524,5 +527,8 @@ int MXDumpNGraphProfile(const char* file_name) {
     } else {
       ngraph_bridge::NGraphStats::get_instance().dump(std::cout);
     }
+#else
+    throw dmlc::Error("MXDumpNGraphProfile requires MXNet built with nGraph.");
+#endif
   API_END();
 }


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
