### PR TITLE
move unomptimized graph dump to before differentiable fusions

### DIFF
--- a/src/ngraph/ngraph_sgcompiler.cc
+++ b/src/ngraph/ngraph_sgcompiler.cc
@@ -209,6 +209,10 @@ std::shared_ptr<ngraph::Function> SGCompiler::MakeForwardFunction(
   // create the Forward Function object representing the graph
   auto func = std::make_shared<ngraph::Function>(outputs, parameters);
 
+  if (ngraph_log_graph()) {
+    dump_graph(func, __func__, "pre-optimized-fprop");
+  }
+
   // fuse conv + bias before autodiff
   if (sub_graph->context_ == mxnet::Context::CPU()) {
     ngraph::pass::Manager pass_manager;
@@ -293,9 +297,6 @@ void SGCompiler::CompileSubgraph(std::shared_ptr<Graph> sub_graph) {
   }
 
   auto f = MakeForwardFunction(sub_graph);
-  if (ngraph_log_graph()) {
-    dump_graph(f, __func__, "pre-optimized-fprop");
-  }
 
   std::shared_ptr<ngraph::Function> maybe_bf;
   std::vector<std::shared_ptr<ngraph::Node>> adjoints;


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
