### PR TITLE
[WIP] Move All Reduce to the backward graph

### DIFF
--- a/src/ngraph/ngraph_emitter.cc
+++ b/src/ngraph/ngraph_emitter.cc
@@ -1031,9 +1031,6 @@ void Emitter::CreateLayerOps() {
 
     NgraphNodePtr scale_grad;
 
-#if MXNET_USE_NGRAPH_DISTRIBUTED
-    grad = std::make_shared<ngraph::op::AllReduce>(grad);
-#endif
     if (clip_gradient >= 0.0f) {
       scale_grad = clip(ng_rescale_grad * grad, -clip_gradient, clip_gradient);
     } else {
@@ -1064,9 +1061,6 @@ void Emitter::CreateLayerOps() {
 
     NgraphNodePtr scale_grad;
 
-#if MXNET_USE_NGRAPH_DISTRIBUTED
-    grad = std::make_shared<ngraph::op::AllReduce>(grad);
-#endif
     if (clip_gradient >= 0.0f) {
       scale_grad = clip(ng_rescale_grad * grad, -clip_gradient, clip_gradient);
     } else {

--- a/src/ngraph/ngraph_sgcompiler.cc
+++ b/src/ngraph/ngraph_sgcompiler.cc
@@ -282,6 +282,12 @@ std::shared_ptr<ngraph::Function> SGCompiler::MakeBackwardFunction(
       back_parameters.begin(), back_parameters.end(), dYdXs.begin(),
       [&adjoint](const NgraphNodePtr &X) { return adjoint.backprop_node(X); });
 
+#if MXNET_USE_NGRAPH_DISTRIBUTED
+  for (size_t i = 0; i < dYdXs.size(); ++i) {
+    dYdXs[i] = std::make_shared<ngraph::op::AllReduce>(dYdXs[i]);
+  }
+#endif
+
   // create the backward function
   back_parameters.insert(back_parameters.begin(), param_adjoints.begin(),
                          param_adjoints.end());


### PR DESCRIPTION
DO NOT MERGE

This adjustment to the distributed training assumes that the full graph is in nGraph, we can't always make that assumption, but we should be able to test performance on RN50 based on this.