### PR TITLE
Remove has_key 

### DIFF
--- a/docker/scripts/lib_validation_testing.py
+++ b/docker/scripts/lib_validation_testing.py
@@ -147,9 +147,14 @@ def runMnistScript(script=None,          # Script to run
         print("Using data directory {}".format(dataDirectory))
     else: 
         optDataDir = ""
-
+        
+    #which python
+    print("The Python version is: {}".format(os.environ['PYTHON_VERSION_NUMBER']))
+    process = subprocess.check_output(["which python"],shell=True)
+    python_lib = process.decode('utf-8').split()[0]
+    
     print("Setting up run in nGraph environment")
-    cmd = "python{} {}".format(os.environ['PYTHON_VERSION_NUMBER'],script )
+    cmd = "{} {}".format(python_lib.strip(),script )
     print("The command for Mnist Script is: {}".format(cmd))
 
     # Hook for testing results detection without having to run multi-hour
@@ -205,10 +210,10 @@ def runResnetScript(script=None,          # Script to run
         raise Exception("runResnetScript() called without parameter batch_size")
 
     #which python
-    process = subprocess.Popen(['which','python'], stdout=subprocess.PIPE)
-    python_lib, err = process.communicate()
-    if (python_lib == ""):
-        python_lib = "python"
+    print("Setting up run in nGraph environment")
+    print("The Python version is: {}".format(os.environ['PYTHON_VERSION_NUMBER']))
+    process = subprocess.check_output(["which python"],shell=True)
+    python_lib = process.decode('utf-8').split()[0]
 
     # -u puts python in unbuffered mode
     #check trainWithNPP
@@ -274,11 +279,11 @@ def runResnetI1KScript(script=None,          # Script to run
     if trainBatchSize is None:
         raise Exception("runResnetScript() called without parameter batch_size")
 
-    #which python
-    process = subprocess.Popen(['which','python'], stdout=subprocess.PIPE)
-    python_lib, err = process.communicate()
-    if (python_lib == ""):
-        python_lib = "python"
+    #which python   
+    print("Setting up run in nGraph environment")
+    print("The Python version is: {}".format(os.environ['PYTHON_VERSION_NUMBER']))
+    process = subprocess.check_output(["which python"],shell=True)
+    python_lib = process.decode('utf-8').split()[0]
 
     # -u puts python in unbuffered mode
     #check trainWithNPP

--- a/docker/scripts/lib_validation_testing.py
+++ b/docker/scripts/lib_validation_testing.py
@@ -154,8 +154,7 @@ def runMnistScript(script=None,          # Script to run
 
     # Hook for testing results detection without having to run multi-hour
     # FW+Dataset tests
-    if (os.environ.has_key('MX_NG_DO_NOT_RUN')
-        and (os.environ['MX_NG_DO_NOT_RUN'] == "1")):
+    if (os.environ['MX_NG_DO_NOT_RUN'] == "1"):
         runLog = runFakeCommand(command=cmd, logID=logID)
     else:
         runLog = runCommand(command=cmd, logID=logID)
@@ -225,8 +224,7 @@ def runResnetScript(script=None,          # Script to run
     # Hook for testing results detection without having to run multi-hour
     # Framework+Dataset tests
     print("MX_NG_DO_NOT_RUN = {}".format(os.environ['MX_NG_DO_NOT_RUN']))
-    if (os.environ.has_key('MX_NG_DO_NOT_RUN')
-        and (os.environ['MX_NG_DO_NOT_RUN'] == "1")):
+    if (os.environ['MX_NG_DO_NOT_RUN'] == "1"):
         runLog = runFakeCommand(command=cmd, logID=logID)
     else:
         runLog = runCommand(command=cmd, logID=logID)
@@ -296,8 +294,7 @@ def runResnetI1KScript(script=None,          # Script to run
     # Hook for testing results detection without having to run multi-hour
     # Framework+Dataset tests
     print("MX_NG_DO_NOT_RUN = {}".format(os.environ['MX_NG_DO_NOT_RUN']))
-    if (os.environ.has_key('MX_NG_DO_NOT_RUN')
-        and (os.environ['MX_NG_DO_NOT_RUN'] == "1")):
+    if (os.environ['MX_NG_DO_NOT_RUN'] == "1"):
         runLog = runFakeCommand(command=cmd, logID=logID)
     else:
         runLog = runCommand(command=cmd, logID=logID)

--- a/docker/scripts/test_mnist_cpu_daily_validation.py
+++ b/docker/scripts/test_mnist_cpu_daily_validation.py
@@ -86,7 +86,7 @@ def test_mlp_mnist_cpu_backend():
     ngraphResults = processOutput(ngraphLog)
     
     lDir = None
-    if os.environ.has_key('TEST_MLP_MNIST_LOG_DIR'):
+    if (os.environ['TEST_MLP_MNIST_LOG_DIR'] != ""):
         lDir = os.path.abspath(os.environ['TEST_MLP_MNIST_LOG_DIR'])
         VT.writeLogToFile(ngraphLog,
                           os.path.join(lDir, 'test_mlp_mnist_cpu_ngraph.log'))

--- a/docker/scripts/test_resnet_cifar_daily_validation.py
+++ b/docker/scripts/test_resnet_cifar_daily_validation.py
@@ -155,7 +155,7 @@ def test_resnet_cifar10_daily_validation():
     ## Need to update the refAccPercent from the paper.
     #tmp_refAccPercent = 3.4
 
-    if os.environ.has_key('TEST_RESNET_CIFAR10_LOG_DIR'):
+    if (os.environ.get('TEST_RESNET_CIFAR10_LOG_DIR') != ''):
         lDir = os.path.abspath(os.environ['TEST_RESNET_CIFAR10_LOG_DIR'])
         VT.writeLogToFile(ngraphLog,
                           os.path.join(lDir, 'test_resnet_cifar10_cpu_ngraph.log'))

--- a/docker/scripts/test_resnet_i1k_daily_validation.py
+++ b/docker/scripts/test_resnet_i1k_daily_validation.py
@@ -142,7 +142,7 @@ def test_resnet_i1k_daily_validation():
     ## Need to update the refAccPercent from the paper.
     #tmp_refAccPercent = 3.4
 
-    if os.environ.has_key('TEST_RESNET_I1K_LOG_DIR'):
+    if (os.environ.get('TEST_RESNET_I1K_LOG_DIR') != ''):
         lDir = os.path.abspath(os.environ['TEST_RESNET_I1K_LOG_DIR'])
         VT.writeLogToFile(ngraphLog,
                           os.path.join(lDir, 'test_resnet_i1k_cpu_ngraph.log'))


### PR DESCRIPTION
## Description ##
- has_key is not supported in os /  Python3 . 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
