### PR TITLE
remove cout utilities that were duplicated in nGraph

### DIFF
--- a/src/ngraph/ngraph_utils.cc
+++ b/src/ngraph/ngraph_utils.cc
@@ -26,27 +26,7 @@ using namespace std;
 
 namespace ngraph_bridge {
 
-std::ostream& operator<<(std::ostream& os, const ngraph::Shape& s) {
-  return container_to_debug_stream(os, s);
-}
-
 std::ostream& operator<<(std::ostream& os, const nnvm::TShape& s) {
-  return container_to_debug_stream(os, s);
-}
-
-std::ostream& operator<<(std::ostream& os, const ngraph::AxisSet& s) {
-  return container_to_debug_stream(os, s, ", ", "{", "}");
-}
-
-std::ostream& operator<<(std::ostream& os, const ngraph::AxisVector& s) {
-  return container_to_debug_stream(os, s);
-}
-
-std::ostream& operator<<(std::ostream& os, const ngraph::Strides& s) {
-  return container_to_debug_stream(os, s);
-}
-
-std::ostream& operator<<(std::ostream& os, const ngraph::CoordinateDiff& s) {
   return container_to_debug_stream(os, s);
 }
 

--- a/src/ngraph/ngraph_utils.h
+++ b/src/ngraph/ngraph_utils.h
@@ -208,26 +208,6 @@ get_default(const NodePtr& node, const std::string& key,
 
 /// Emits a programmer-friendly representation, to assist with logging
 /// and debugging.
-std::ostream& operator<<(std::ostream& os, const ngraph::Shape& s);
-
-/// Emits a programmer-friendly representation, to assist with logging
-/// and debugging.
-std::ostream& operator<<(std::ostream& os, const ngraph::AxisSet& s);
-
-/// Emits a programmer-friendly representation, to assist with logging
-/// and debugging.
-std::ostream& operator<<(std::ostream& os, const ngraph::Strides& s);
-
-/// Emits a programmer-friendly representation, to assist with logging
-/// and debugging.
-std::ostream& operator<<(std::ostream& os, const ngraph::AxisVector& s);
-
-/// Emits a programmer-friendly representation, to assist with logging
-/// and debugging.
-std::ostream& operator<<(std::ostream& os, const ngraph::CoordinateDiff& s);
-
-/// Emits a programmer-friendly representation, to assist with logging
-/// and debugging.
 std::ostream& operator<<(std::ostream& os, const nnvm::TShape& s);
 
 /// A convenience method to obtain the elements of s1 that are not


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
