### PR TITLE
make Gluon default, add Stateful ops support for gluon imperative

### DIFF
--- a/3rdparty/ngraph_bridge/src/ngraph_compiler.cc
+++ b/3rdparty/ngraph_bridge/src/ngraph_compiler.cc
@@ -494,7 +494,7 @@ void Compiler::CheckInNgraph() {
       if (ngraph_log_verbose()) {
         unsupported_op_names.insert(node->operation_);
       }
-      if (ngraph_log_verbose_detail()) {
+      if (ngraph_log_verbose_detail) {
         std::cout << "NGRAPH_BRIDGE: Unsupported Op instance (verbose):"
                   << std::endl;
         node->printOpDetails(std::cout);

--- a/3rdparty/ngraph_bridge/src/ngraph_emitter.cc
+++ b/3rdparty/ngraph_bridge/src/ngraph_emitter.cc
@@ -1677,7 +1677,7 @@ void Emitter::UnsupportedOps() {
     auto conv = create_deconvolution(data, filter, out_shape, node->orig_node_);
 
     if (conv->get_shape() != TShape_to_NShape(node->shape_)) {
-      if (ngraph_log_verbose_detail()) {
+      if (ngraph_log_verbose_detail) {
         std::cout << "NGRAPH_BRIDGE: Deconvolution with adjust and target "
                      "shape is not tested in MXNet."
                   << std::endl;

--- a/3rdparty/ngraph_bridge/src/ngraph_imperative.cc
+++ b/3rdparty/ngraph_bridge/src/ngraph_imperative.cc
@@ -266,11 +266,12 @@ void InitImperativeOnce() {
                          const std::vector<mxnet::OpReqType> &req,
                          const std::vector<mxnet::TBlob> &outputs) -> void {
             auto &op_state = state.get_state<StateFCompute>();
-            std::vector<mxnet::NDArray> in;
-            for (auto &i : inputs) in.emplace_back(i, ctx.run_ctx.ctx.dev_id);
-            std::vector<mxnet::NDArray> out;
-            for (auto &i : outputs) out.emplace_back(i, ctx.run_ctx.ctx.dev_id);
             if (!ctx.is_train) {
+              std::vector<mxnet::NDArray> in;
+              for (auto &i : inputs) in.emplace_back(i, ctx.run_ctx.ctx.dev_id);
+              std::vector<mxnet::NDArray> out;
+              for (auto &i : outputs)
+                out.emplace_back(i, ctx.run_ctx.ctx.dev_id);
               if (!op_state.ngraph_) {
                 compute_forward_imperative(op_state.attrs, ctx, in, req, out,
                                            op_state.ngraph_);

--- a/3rdparty/ngraph_bridge/src/ngraph_imperative.cc
+++ b/3rdparty/ngraph_bridge/src/ngraph_imperative.cc
@@ -207,7 +207,7 @@ void InitImperativeOnce() {
                          const std::vector<mxnet::NDArray> &inputs,
                          const std::vector<mxnet::OpReqType> &req,
                          const std::vector<mxnet::NDArray> &outputs) -> void {
-            if (ctx.is_train ||
+            if (ctx.is_train || ctx.need_grad || 
                 !compute_forward_imperative(attrs, ctx, inputs, req, outputs)) {
               // use default mxnet compute kernel
               fallbackx_fn(attrs, ctx, inputs, req, outputs);
@@ -231,7 +231,7 @@ void InitImperativeOnce() {
             for (auto &i : inputs) in.emplace_back(i, ctx.run_ctx.ctx.dev_id);
             std::vector<mxnet::NDArray> out;
             for (auto &i : outputs) out.emplace_back(i, ctx.run_ctx.ctx.dev_id);
-            if (ctx.is_train ||
+            if (ctx.is_train || ctx.need_grad ||
                 !compute_forward_imperative(attrs, ctx, in, req, out)) {
               // use default mxnet compute kernel
               fallback_fn(attrs, ctx, inputs, req, outputs);
@@ -264,7 +264,7 @@ void InitImperativeOnce() {
                          const std::vector<mxnet::OpReqType> &req,
                          const std::vector<mxnet::TBlob> &outputs) -> void {
             auto &op_state = state.get_state<StateFCompute>();
-            if (!ctx.is_train) {
+            if (!(ctx.is_train || ctx.need_grad)) {
               std::vector<mxnet::NDArray> in;
               for (auto &i : inputs) in.emplace_back(i, ctx.run_ctx.ctx.dev_id);
               std::vector<mxnet::NDArray> out;

--- a/3rdparty/ngraph_bridge/src/ngraph_imperative.cc
+++ b/3rdparty/ngraph_bridge/src/ngraph_imperative.cc
@@ -116,28 +116,26 @@ bool compute_forward_imperative(const nnvm::NodeAttrs &attrs,
     if (!op_ng) {
       NGImperative ngi(attrs, ctx.run_ctx.ctx, inputs, &req, outputs);
       op_ng = ngicache[op_key] = ngi.get_op_ngraph();
-      if (ngraph_log_verbose_detail && op_ng) {
-        LOG(INFO) << "Caching... " << attrs.op->name;
-      }
     }
   }
   // op_ng can be null if sgcompiler could not create ngraph IR
   // we fallback to mxnet kernel in this case
   if (op_ng && op_ng->ngraph_forward[mode]) {
-    if (ngraph_log_verbose_detail) {
-      LOG(INFO) << "ngraph imperative op: " << attrs.op->name << ", inputs "
-                << std::to_string(inputs.size()) << ", outputs "
-                << std::to_string(outputs.size());
+#ifndef NDEBUG
+    // log imperative op details in debug mode
+    LOG(INFO) << "ngraph imperative op: " << attrs.op->name << ", inputs "
+              << std::to_string(inputs.size()) << ", outputs "
+              << std::to_string(outputs.size());
 
-      for (const auto &m : attrs.dict) {
-        LOG(INFO) << "attrs.dict[" << m.first << "] = " << m.second;
-      }
+    for (const auto &m : attrs.dict) {
+      LOG(INFO) << "attrs.dict[" << m.first << "] = " << m.second;
     }
+#endif
     compute_forward(ctx, op_ng, inputs, req, outputs);
     return true;
   }
   return false;
-}
+}  // namespace ngraph_bridge
 
 struct StateFCompute {
   std::shared_ptr<Graph> ngraph_;

--- a/3rdparty/ngraph_bridge/src/ngraph_imperative.h
+++ b/3rdparty/ngraph_bridge/src/ngraph_imperative.h
@@ -52,8 +52,7 @@ class NGImperative : public Compiler {
     static OpEmitter emitter_funcs = Emitter().ngraph_op_funcs_;
 
     static std::unordered_set<std::string> skip_imperative{
-        "expand_dims", "_copy",       "_zeros",
-        "zeros_like",  "_mul_scalar", "SliceChannel"};
+        "_copy", "_zeros", "zeros_like", "expand_dims"};
 
     if (skip_imperative.count(op_name)) return false;
 

--- a/3rdparty/ngraph_bridge/src/ngraph_imperative.h
+++ b/3rdparty/ngraph_bridge/src/ngraph_imperative.h
@@ -50,18 +50,14 @@ class NGImperative : public Compiler {
   // check for ops supported by ngraph_bridge and imperative interface
   static bool check_op_supported(std::string op_name) {
     static OpEmitter emitter_funcs = Emitter().ngraph_op_funcs_;
-    static std::unordered_set<std::string> layer_and_other{"split",
-                                                           "SliceChannel"};
 
     static std::unordered_set<std::string> skip_imperative{
-        "expand_dims", "_copy",     "_zeros",
-        "zeros_like",  "BatchNorm", "_mul_scalar"};
+        "expand_dims", "_copy",       "_zeros",      "zeros_like",
+        "BatchNorm",   "_mul_scalar", "SliceChannel"};
 
     if (skip_imperative.count(op_name)) return false;
 
-    if (emitter_funcs.count(op_name) || layer_and_other.count(op_name) ||
-        nameswitch.count(op_name))
-      return true;
+    if (emitter_funcs.count(op_name) || nameswitch.count(op_name)) return true;
 
     return false;
   }

--- a/3rdparty/ngraph_bridge/src/ngraph_imperative.h
+++ b/3rdparty/ngraph_bridge/src/ngraph_imperative.h
@@ -52,8 +52,8 @@ class NGImperative : public Compiler {
     static OpEmitter emitter_funcs = Emitter().ngraph_op_funcs_;
 
     static std::unordered_set<std::string> skip_imperative{
-        "expand_dims", "_copy",       "_zeros",      "zeros_like",
-        "BatchNorm",   "_mul_scalar", "SliceChannel"};
+        "expand_dims", "_copy",       "_zeros",
+        "zeros_like",  "_mul_scalar", "SliceChannel"};
 
     if (skip_imperative.count(op_name)) return false;
 

--- a/3rdparty/ngraph_bridge/src/ngraph_utils.h
+++ b/3rdparty/ngraph_bridge/src/ngraph_utils.h
@@ -55,9 +55,8 @@ inline bool ngraph_log_viz() {
 inline bool ngraph_log_timer() {
   return dmlc::GetEnv("MXNET_NGRAPH_TIMER", false);
 }
-inline bool ngraph_log_verbose_detail() {
-  return dmlc::GetEnv("MXNET_NGRAPH_VERBOSE_DETAIL", false);
-}
+const bool ngraph_log_verbose_detail =
+    dmlc::GetEnv("MXNET_NGRAPH_VERBOSE_DETAIL", false);
 
 // simple timer for sequential blocks of code
 class Timer {

--- a/3rdparty/ngraph_bridge/src/ngraph_utils.h
+++ b/3rdparty/ngraph_bridge/src/ngraph_utils.h
@@ -34,7 +34,7 @@ namespace ngraph_bridge {
 
 // enable ngraph gluon at runtime.
 inline bool ngraph_gluon_enable() {
-  return dmlc::GetEnv("MXNET_NGRAPH_GLUON", false);
+  return dmlc::GetEnv("MXNET_NGRAPH_GLUON", true);
 }
 
 // enable distributed ngraph at runtime

--- a/tests/python/unittest/test_autograd.py
+++ b/tests/python/unittest/test_autograd.py
@@ -100,11 +100,11 @@ def autograd_assert(*args, **kwargs):
     grad_func = grad_and_loss(func, argnum)
     grad_vals, output = grad_func(*args)
     res = func(*args)
-    assert same(output.asnumpy(), res.asnumpy())
+    assert almost_equal(output.asnumpy(), res.asnumpy())
     grad_res = grad_f(*args)
     assert len(grad_vals) == len(grad_res)
     for a, b in zip(grad_vals, grad_res):
-        assert same(a.asnumpy(), b.asnumpy())
+        assert almost_equal(a.asnumpy(), b.asnumpy())
 
 @with_seed()
 def test_unary_func():

--- a/tests/python/unittest/test_contrib_autograd.py
+++ b/tests/python/unittest/test_contrib_autograd.py
@@ -28,11 +28,11 @@ def autograd_assert(*args, **kwargs):
     grad_func = grad_and_loss(func, argnum)
     grad_vals, output = grad_func(*args)
     res = func(*args)
-    assert same(output.asnumpy(), res.asnumpy())
+    assert almost_equal(output.asnumpy(), res.asnumpy())
     grad_res = grad_f(*args)
     assert len(grad_vals) == len(grad_res)
     for a, b in zip(grad_vals, grad_res):
-        assert same(a.asnumpy(), b.asnumpy())
+        assert almost_equal(a.asnumpy(), b.asnumpy())
 
 @with_seed()
 def test_unary_func():


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
