### PR TITLE
Fix a bug in SoftmaxOutput that affects FasterRCNN training

### DIFF
--- a/3rdparty/ngraph_bridge/src/ngraph_emitter.cc
+++ b/3rdparty/ngraph_bridge/src/ngraph_emitter.cc
@@ -1482,6 +1482,18 @@ void Emitter::CreateLossOps() {
     auto label = op_map_[node->inputs_[1]];
     bool ignore = false;
     NgraphNodePtr mask;
+
+    if (get_default(node, "multi_output", false)) {
+      ngraph::Shape new_shape{label->get_shape()[0]};
+      new_shape.insert(new_shape.end(), begin(softmax->get_shape()) + 2,
+                       end(softmax->get_shape()));
+      if (shape_size(new_shape) != shape_size(label->get_shape())) {
+        new_shape.insert(begin(new_shape) + 1, shape_size(label->get_shape()) /
+                                                   shape_size(new_shape));
+      }
+      label = std::make_shared<ngraph::op::Reshape>(
+          label, pyrange(label->get_shape().size()), new_shape);
+    }
     if (label->get_shape() != softmax->get_shape()) {
       if (use_ignore) {
         ignore = true;

--- a/3rdparty/ngraph_bridge/src/ngraph_sgcompiler.cc
+++ b/3rdparty/ngraph_bridge/src/ngraph_sgcompiler.cc
@@ -107,7 +107,8 @@ void CompileForwardBackward(std::shared_ptr<Graph> sub_graph,
         auto cloned_bf_param = bfmap.get(bf_param);
         auto layout =
             cloned_result->get_output_tensor_view()->get_tensor_view_layout();
-        cloned_bf_param->get_output_tensor_view()->set_tensor_view_layout(layout);
+        cloned_bf_param->get_output_tensor_view()->set_tensor_view_layout(
+            layout);
       }
     }
   }


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
