### PR TITLE
Disable 2 tests test_det_augmenters ,test_image_detiter

### DIFF
--- a/tests/python/unittest/test_image.py
+++ b/tests/python/unittest/test_image.py
@@ -234,7 +234,7 @@ class TestImage(unittest.TestCase):
         for batch in test_iter:
             pass
 
-    #@unittest.skip("The test fail with python errors. Temporarily disabled till it gets fixed")
+    @unittest.skip("The test fail with python errors. Temporarily disabled till it gets fixed")
     def test_image_detiter(self):
         im_list = [_generate_objects() + [x] for x in TestImage.IMAGES]
         det_iter = mx.image.ImageDetIter(2, (3, 300, 300), imglist=im_list, path_root='')
@@ -259,7 +259,7 @@ class TestImage(unittest.TestCase):
         for batch in det_iter:
             pass
 
-    #@unittest.skip("The test fail with python errors. Temporarily disabled till it gets fixed")
+    @unittest.skip("The test fail with python errors. Temporarily disabled till it gets fixed")
     def test_det_augmenters(self):
         # only test if all augmenters will work
         # TODO(Joshua Zhang): verify the augmenter outputs


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
