### PR TITLE
NGRAPH-2762: Add DeepSpeed2

### DIFF
--- a/docker/scripts/config-mx.sh
+++ b/docker/scripts/config-mx.sh
@@ -44,6 +44,5 @@ echo "WARPCTC_PATH = ${WARPCTC_DIR}" >> ${MX_DIR}/make/config.mk
 echo "MXNET_PLUGINS += plugin/warpctc/warpctc.mk" >> ${MX_DIR}/make/config.mk 
 
 export LD_LIBRARY_PATH="${WARPCTC_DIR}/build"${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-echo ${LD_LIBRARY_PATH}
 
 echo "Success."

--- a/docker/scripts/config-mx.sh
+++ b/docker/scripts/config-mx.sh
@@ -31,13 +31,6 @@ cd build
 cmake ../
 make
 
-if [ ! -f "./build/libwarpctc.so" ] ; then
-  ( >&2 echo "FATAL ERROR: Can not found libwarpctc.so. Exiting ...." )
-  exit 1
-else
-   echo "Success to install warpctc."
-fi
-
 cd ${MX_DIR}
 #sed -e '/^USE_NGRAPH/s/.*/USE_NGRAPH = 1/' -e '/^USE_MKL2017/s/.*/USE_MKL2017 = 0/' -e '/^USE_NNPACK/s/.*/USE_NNPACK = 0/' -e "s@\(NGRAPH_DIR = *\)@\1 ${NGRAPH_DIR}@g" ${MX_DIR}/make/config.mk > ${MX_DIR}/make/config.mk.tmp
 echo "Updatind config.mk to enable WARP-CTC..."

--- a/docker/scripts/config-mx.sh
+++ b/docker/scripts/config-mx.sh
@@ -24,10 +24,21 @@ declare SCRIPT_NAME="$(basename "${0}")"
 declare THIS_SCRIPT_DIR="$( cd $(dirname "${BASH_SOURCE[0]}") && pwd )"
 declare MX_DIR="$(cd "${THIS_SCRIPT_DIR}/../.." && pwd)"
 declare WARPCTC_DIR="${MX_DIR}/warp-ctc"
-echo "Configure Mxnet..."
+echo "Installing WARP-CTC..."
+mkdir build
+cd build
+cmake ../
+make
+
+if [ ! -f "./build/libwarpctc.so" ] ; then
+  ( >&2 echo "FATAL ERROR: Can not found libwarpctc.so. Exiting ...." )
+  exit 1
+else
+   echo "Success to install warpctc."
+fi
 
 #sed -e '/^USE_NGRAPH/s/.*/USE_NGRAPH = 1/' -e '/^USE_MKL2017/s/.*/USE_MKL2017 = 0/' -e '/^USE_NNPACK/s/.*/USE_NNPACK = 0/' -e "s@\(NGRAPH_DIR = *\)@\1 ${NGRAPH_DIR}@g" ${MX_DIR}/make/config.mk > ${MX_DIR}/make/config.mk.tmp
-
+echo "Updatind config.mk to enable WARP-CTC..."
 echo "WARPCTC_PATH = ${WARPCTC_DIR}/warp-ctc" >> ${MX_DIR}/make/config.mk 
 echo "MXNET_PLUGINS += plugin/warpctc/warpctc.mk" >> ${MX_DIR}/make/config.mk 
 

--- a/docker/scripts/config-mx.sh
+++ b/docker/scripts/config-mx.sh
@@ -23,17 +23,12 @@ set -e
 declare SCRIPT_NAME="$(basename "${0}")"
 declare THIS_SCRIPT_DIR="$( cd $(dirname "${BASH_SOURCE[0]}") && pwd )"
 declare MX_DIR="$(cd "${THIS_SCRIPT_DIR}/../.." && pwd)"
-declare NGRAPH_DIR="${MX_DIR}/ngraph_dist"
+declare WARPCTC_DIR="${MX_DIR}/warp-ctc"
 echo "Configure Mxnet..."
 
-#Modify the config.mk 
-#USE_NGRAPH = 1
-#USE_MKL2017 = 0
-#USE_NNPACK = 0
-#Fill out the directory of NGRAPH_DIR
+#sed -e '/^USE_NGRAPH/s/.*/USE_NGRAPH = 1/' -e '/^USE_MKL2017/s/.*/USE_MKL2017 = 0/' -e '/^USE_NNPACK/s/.*/USE_NNPACK = 0/' -e "s@\(NGRAPH_DIR = *\)@\1 ${NGRAPH_DIR}@g" ${MX_DIR}/make/config.mk > ${MX_DIR}/make/config.mk.tmp
 
-sed -e '/^USE_NGRAPH/s/.*/USE_NGRAPH = 1/' -e '/^USE_MKL2017/s/.*/USE_MKL2017 = 0/' -e '/^USE_NNPACK/s/.*/USE_NNPACK = 0/' -e "s@\(NGRAPH_DIR = *\)@\1 ${NGRAPH_DIR}@g" ${MX_DIR}/make/config.mk > ${MX_DIR}/make/config.mk.tmp
-
-cp ${MX_DIR}/make/config.mk.tmp  ${MX_DIR}/make/config.mk
+echo "WARPCTC_PATH = ${WARPCTC_DIR}/warp-ctc" >> ${MX_DIR}/make/config.mk 
+echo "MXNET_PLUGINS += plugin/warpctc/warpctc.mk" >> ${MX_DIR}/make/config.mk 
 
 echo "Success."

--- a/docker/scripts/config-mx.sh
+++ b/docker/scripts/config-mx.sh
@@ -43,6 +43,7 @@ echo "Updatind config.mk to enable WARP-CTC..."
 echo "WARPCTC_PATH = ${WARPCTC_DIR}" >> ${MX_DIR}/make/config.mk 
 echo "MXNET_PLUGINS += plugin/warpctc/warpctc.mk" >> ${MX_DIR}/make/config.mk 
 
-export LD_LIBRARY_PATH=${WARPCTC_DIR}/build:${LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH="${WARPCTC_DIR}/build"${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+echo ${LD_LIBRARY_PATH}
 
 echo "Success."

--- a/docker/scripts/config-mx.sh
+++ b/docker/scripts/config-mx.sh
@@ -23,7 +23,6 @@ set -e
 declare SCRIPT_NAME="$(basename "${0}")"
 declare THIS_SCRIPT_DIR="$( cd $(dirname "${BASH_SOURCE[0]}") && pwd )"
 declare MX_DIR="$(cd "${THIS_SCRIPT_DIR}/../.." && pwd)"
-echo "=== MX_DIR = ${MX_DIR} "
 declare WARPCTC_DIR="${MX_DIR}/warp-ctc"
 cd ${WARPCTC_DIR}
 echo "Installing WARP-CTC..."
@@ -32,16 +31,18 @@ cd build
 cmake ../
 make  -j 
 
-echo "=== MX_DIR = ${MX_DIR} "
+rc=$?
+if [ $rc -ne 0 ];then
+    echo "Failed to build warp-ctc"
+    exit $rc
+fi
+
 cd ${MX_DIR}
 #sed -e '/^USE_NGRAPH/s/.*/USE_NGRAPH = 1/' -e '/^USE_MKL2017/s/.*/USE_MKL2017 = 0/' -e '/^USE_NNPACK/s/.*/USE_NNPACK = 0/' -e "s@\(NGRAPH_DIR = *\)@\1 ${NGRAPH_DIR}@g" ${MX_DIR}/make/config.mk > ${MX_DIR}/make/config.mk.tmp
 echo "Updatind config.mk to enable WARP-CTC..."
 echo "WARPCTC_PATH = ${WARPCTC_DIR}" >> ${MX_DIR}/make/config.mk 
 echo "MXNET_PLUGINS += plugin/warpctc/warpctc.mk" >> ${MX_DIR}/make/config.mk 
 
-cp ${MX_DIR}/warp-ctc/build/libwarpctc.so usr/lib
+export LD_LIBRARY_PATH=${WARPCTC_DIR}/build:${LD_LIBRARY_PATH}
 
-echo "=========== "
-cat ${MX_DIR}/make/config.mk 
-echo "=========== "
 echo "Success."

--- a/docker/scripts/config-mx.sh
+++ b/docker/scripts/config-mx.sh
@@ -24,6 +24,7 @@ declare SCRIPT_NAME="$(basename "${0}")"
 declare THIS_SCRIPT_DIR="$( cd $(dirname "${BASH_SOURCE[0]}") && pwd )"
 declare MX_DIR="$(cd "${THIS_SCRIPT_DIR}/../.." && pwd)"
 declare WARPCTC_DIR="${MX_DIR}/warp-ctc"
+cd ${WARPCTC_DIR}
 echo "Installing WARP-CTC..."
 mkdir build
 cd build
@@ -37,6 +38,7 @@ else
    echo "Success to install warpctc."
 fi
 
+cd ${MX_DIR}
 #sed -e '/^USE_NGRAPH/s/.*/USE_NGRAPH = 1/' -e '/^USE_MKL2017/s/.*/USE_MKL2017 = 0/' -e '/^USE_NNPACK/s/.*/USE_NNPACK = 0/' -e "s@\(NGRAPH_DIR = *\)@\1 ${NGRAPH_DIR}@g" ${MX_DIR}/make/config.mk > ${MX_DIR}/make/config.mk.tmp
 echo "Updatind config.mk to enable WARP-CTC..."
 echo "WARPCTC_PATH = ${WARPCTC_DIR}/warp-ctc" >> ${MX_DIR}/make/config.mk 

--- a/docker/scripts/config-mx.sh
+++ b/docker/scripts/config-mx.sh
@@ -30,7 +30,7 @@ echo "Installing WARP-CTC..."
 mkdir build
 cd build
 cmake ../
-make
+make  -j 
 
 echo "=== MX_DIR = ${MX_DIR} "
 cd ${MX_DIR}
@@ -38,6 +38,8 @@ cd ${MX_DIR}
 echo "Updatind config.mk to enable WARP-CTC..."
 echo "WARPCTC_PATH = ${WARPCTC_DIR}" >> ${MX_DIR}/make/config.mk 
 echo "MXNET_PLUGINS += plugin/warpctc/warpctc.mk" >> ${MX_DIR}/make/config.mk 
+
+cp ${MX_DIR}/warp-ctc/build/libwarpctc.so usr/lib
 
 echo "=========== "
 cat ${MX_DIR}/make/config.mk 

--- a/docker/scripts/config-mx.sh
+++ b/docker/scripts/config-mx.sh
@@ -23,6 +23,7 @@ set -e
 declare SCRIPT_NAME="$(basename "${0}")"
 declare THIS_SCRIPT_DIR="$( cd $(dirname "${BASH_SOURCE[0]}") && pwd )"
 declare MX_DIR="$(cd "${THIS_SCRIPT_DIR}/../.." && pwd)"
+echo "=== MX_DIR = ${MX_DIR} "
 declare WARPCTC_DIR="${MX_DIR}/warp-ctc"
 cd ${WARPCTC_DIR}
 echo "Installing WARP-CTC..."
@@ -31,10 +32,14 @@ cd build
 cmake ../
 make
 
+echo "=== MX_DIR = ${MX_DIR} "
 cd ${MX_DIR}
 #sed -e '/^USE_NGRAPH/s/.*/USE_NGRAPH = 1/' -e '/^USE_MKL2017/s/.*/USE_MKL2017 = 0/' -e '/^USE_NNPACK/s/.*/USE_NNPACK = 0/' -e "s@\(NGRAPH_DIR = *\)@\1 ${NGRAPH_DIR}@g" ${MX_DIR}/make/config.mk > ${MX_DIR}/make/config.mk.tmp
 echo "Updatind config.mk to enable WARP-CTC..."
-echo "WARPCTC_PATH = ${WARPCTC_DIR}/warp-ctc" >> ${MX_DIR}/make/config.mk 
+echo "WARPCTC_PATH = ${WARPCTC_DIR}" >> ${MX_DIR}/make/config.mk 
 echo "MXNET_PLUGINS += plugin/warpctc/warpctc.mk" >> ${MX_DIR}/make/config.mk 
 
+echo "=========== "
+cat ${MX_DIR}/make/config.mk 
+echo "=========== "
 echo "Success."

--- a/docker/scripts/lib_validation_testing.py
+++ b/docker/scripts/lib_validation_testing.py
@@ -362,6 +362,34 @@ def runBenchmarkScoreScript(script=None,          # Script to run
 
 # End: def runBenchmarkScoreScript()
 
+def runDSDeepMarkScript(sourceDir=None,
+                    script=None,          # Script to run
+                   logID='',
+                   ompNumThreads=None,
+                   kmpAff=None,
+                   kmpBlocktime=None,
+                   batchsize=None,
+                   checkAccurary=None):            # Log line prefix
+
+    print("DeepMark script being run with:")
+    print("    script:         {}".format(str(script)))
+    print("    logID:          {}".format(str(logID)))
+
+    print("Setting up run in nGraph environment")
+    print("The Python version is: {}".format(os.environ['PYTHON_VERSION_NUMBER']))
+    process = subprocess.check_output(["which python"],shell=True)
+    python_lib = process.decode('utf-8').split()[0]
+    if checkAccurary:
+        cmd = "OMP_NUM_THREADS={} KMP_AFFINITY={} KMP_BLOCKTIME={} {} {} --network DeepSpeech2 --batch-size {} --accuracy-check".format(ompNumThreads, kmpAff, kmpBlocktime, python_lib.strip(), script, batchsize.strip())
+        print("The command for checking inference accuracy is: {}".format(cmd))
+    else:
+        cmd = "OMP_NUM_THREADS={} KMP_AFFINITY={} KMP_BLOCKTIME={} {} {} --network DeepSpeech2 --batch-size {}".format(ompNumThreads, kmpAff, kmpBlocktime, python_lib.strip(), script, batchsize.strip())
+        print("The command for checking inference performance is: {}".format(cmd))
+    runLog = runCommand(command=cmd, logID=logID)
+    return runLog
+
+# End: def runDSDeepMarkScript()
+
 def runInceptionV4Script(sourceDir=None,
                     script=None,          # Script to run
                    logID='',

--- a/docker/scripts/run-ng-mx-deepmark-tests.sh
+++ b/docker/scripts/run-ng-mx-deepmark-tests.sh
@@ -51,10 +51,7 @@ run_inference_topologies() {
     export TEST_BATCH_SIZE="${MX_NG_BATCH_SIZE}"
     export TEST_KMP_AFFINITY="${MX_NG_KMP_AFFINITY}"
     export TEST_DEEPMARK_TYPE="${MX_NG_DEEPMARK_TYPE}"
-
     export LD_LIBRARY_PATH="${HOME}/ng-mx/warp-ctc/build"${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-    echo "LD_LIBRARY_PATH 2 :======"
-    echo ${LD_LIBRARY_PATH}
 
     if [ "${TEST_BATCH_SIZE}" == "1" ] ; then
         # Run the Faster-RCNN, --batch-size 1

--- a/docker/scripts/run-ng-mx-deepmark-tests.sh
+++ b/docker/scripts/run-ng-mx-deepmark-tests.sh
@@ -69,64 +69,64 @@ run_inference_topologies() {
     eval $cmd
 
     # Run the inception_v4
-    #cmd="pytest -s docker/scripts/test_deepmark_inception_v4_inference.py --junit-xml=validation_test_deepmark_inception_v4_inference.xml --junit-prefix=inference_deepmark_inception_v4_cpu"
-    #eval $cmd
+    cmd="pytest -s docker/scripts/test_deepmark_inception_v4_inference.py --junit-xml=validation_test_deepmark_inception_v4_inference.xml --junit-prefix=inference_deepmark_inception_v4_cpu"
+    eval $cmd
 
     # Run the inception_v3
-    #cmd="pytest -s docker/scripts/test_deepmark_inception_v3_inference.py --junit-xml=validation_test_deepmark_inception_v3_inference.xml --junit-prefix=inference_deepmark_inception_v3_cpu"
-    #eval $cmd
+    cmd="pytest -s docker/scripts/test_deepmark_inception_v3_inference.py --junit-xml=validation_test_deepmark_inception_v3_inference.xml --junit-prefix=inference_deepmark_inception_v3_cpu"
+    eval $cmd
 
     # Run the inception_resnet_v2
-    #cmd="pytest -s docker/scripts/test_deepmark_inception_resnet_v2_inference.py --junit-xml=validation_test_deepmark_inception_resnet_v2_inference.xml --junit-prefix=inference_deepmark_inception_resnet_v2_cpu"
-    #eval $cmd
+    cmd="pytest -s docker/scripts/test_deepmark_inception_resnet_v2_inference.py --junit-xml=validation_test_deepmark_inception_resnet_v2_inference.xml --junit-prefix=inference_deepmark_inception_resnet_v2_cpu"
+    eval $cmd
 
     # Run the resnet_50
-    #cmd="pytest -s docker/scripts/test_deepmark_resnet_50_inference.py --junit-xml=validation_test_deepmark_resnet_50_inference.xml --junit-prefix=inference_deepmark_resnet_50_cpu"
-    #eval $cmd
+    cmd="pytest -s docker/scripts/test_deepmark_resnet_50_inference.py --junit-xml=validation_test_deepmark_resnet_50_inference.xml --junit-prefix=inference_deepmark_resnet_50_cpu"
+    eval $cmd
 
     # Run the a3c
-    #cmd="pytest -s docker/scripts/test_deepmark_a3c_inference.py --junit-xml=validation_test_deepmark_a3c_inference.xml --junit-prefix=inference_deepmark_a3c_cpu"
-    #eval $cmd
+    cmd="pytest -s docker/scripts/test_deepmark_a3c_inference.py --junit-xml=validation_test_deepmark_a3c_inference.xml --junit-prefix=inference_deepmark_a3c_cpu"
+    eval $cmd
 
     # Run the test wide_deep
-    #cmd="pytest -s docker/scripts/test_deepmark_wide_deep_inference.py --junit-xml=validation_test_deepmark_wide_deep_inference.xml --junit-prefix=inference_deepmark_wide_deep_cpu"
-    #eval $cmd
+    cmd="pytest -s docker/scripts/test_deepmark_wide_deep_inference.py --junit-xml=validation_test_deepmark_wide_deep_inference.xml --junit-prefix=inference_deepmark_wide_deep_cpu"
+    eval $cmd
 
     # Run the test mobilenet
-    #cmd="pytest -s docker/scripts/test_deepmark_mobilenet_inference.py --junit-xml=validation_test_deepmark_mobilenet_inference.xml --junit-prefix=inference_deepmark_mobilenet_cpu"
-    #eval $cmd
+    cmd="pytest -s docker/scripts/test_deepmark_mobilenet_inference.py --junit-xml=validation_test_deepmark_mobilenet_inference.xml --junit-prefix=inference_deepmark_mobilenet_cpu"
+    eval $cmd
 
     # Run the densenet121
-    #cmd="pytest -s docker/scripts/test_deepmark_densenet121_inference.py --junit-xml=validation_test_deepmark_densenet121_inference.xml --junit-prefix=inference_deepmark_densenet121_cpu"
-    #eval $cmd
+    cmd="pytest -s docker/scripts/test_deepmark_densenet121_inference.py --junit-xml=validation_test_deepmark_densenet121_inference.xml --junit-prefix=inference_deepmark_densenet121_cpu"
+    eval $cmd
 
     # Run the squeezenet1.1
-    #cmd="pytest -s docker/scripts/test_deepmark_squeezenet_inference.py --junit-xml=validation_test_deepmark_squeezenet_inference.xml --junit-prefix=inference_deepmark_squeezenet_cpu"
-    #eval $cmd
+    cmd="pytest -s docker/scripts/test_deepmark_squeezenet_inference.py --junit-xml=validation_test_deepmark_squeezenet_inference.xml --junit-prefix=inference_deepmark_squeezenet_cpu"
+    eval $cmd
 
     # Run DCGAN 
-    #cmd="pytest -s docker/scripts/test_deepmark_dcgan_inference.py --junit-xml=validation_test_deepmark_dcgan_inference.xml --junit-prefix=inference_deepmark_dcgan_cpu"
-    #eval $cmd
+    cmd="pytest -s docker/scripts/test_deepmark_dcgan_inference.py --junit-xml=validation_test_deepmark_dcgan_inference.xml --junit-prefix=inference_deepmark_dcgan_cpu"
+    eval $cmd
 
     # Run  sockeye_transformer
-    #cmd="pytest -s docker/scripts/test_deepmark_sockeye_transformer_inference.py --junit-xml=validation_test_deepmark_sockeye_transformer_inference.xml --junit-prefix=inference_deepmark_sockeye_transformer_cpu"
-    #eval $cmd
+    cmd="pytest -s docker/scripts/test_deepmark_sockeye_transformer_inference.py --junit-xml=validation_test_deepmark_sockeye_transformer_inference.xml --junit-prefix=inference_deepmark_sockeye_transformer_cpu"
+    eval $cmd
 
     # Run  sockeye_gnmt
-    #cmd="pytest -s docker/scripts/test_deepmark_sockeye_gnmt_inference.py --junit-xml=validation_test_deepmark_sockeye_gnmt_inference.xml --junit-prefix=inference_deepmark_sockeye_gnmt_cpu"
-    #eval $cmd
+    cmd="pytest -s docker/scripts/test_deepmark_sockeye_gnmt_inference.py --junit-xml=validation_test_deepmark_sockeye_gnmt_inference.xml --junit-prefix=inference_deepmark_sockeye_gnmt_cpu"
+    eval $cmd
 
     # Run ssd_512_mobilenet1_0_voc 
-    #cmd="pytest -s docker/scripts/test_deepmark_ssd_512_mobilenet_inference.py --junit-xml=validation_test_deepmark_ssd_512_mobilenet_inference.xml --junit-prefix=inference_deepmark_ssd_512_mobilenet_cpu"
-    #eval $cmd
+    cmd="pytest -s docker/scripts/test_deepmark_ssd_512_mobilenet_inference.py --junit-xml=validation_test_deepmark_ssd_512_mobilenet_inference.xml --junit-prefix=inference_deepmark_ssd_512_mobilenet_cpu"
+    eval $cmd
 
     # Run ssd
-    #cmd="pytest -s docker/scripts/test_deepmark_ssd_inference.py --junit-xml=validation_test_deepmark_ssd_inference.xml --junit-prefix=inference_deepmark_ssd_cpu"
-    #eval $cmd
+    cmd="pytest -s docker/scripts/test_deepmark_ssd_inference.py --junit-xml=validation_test_deepmark_ssd_inference.xml --junit-prefix=inference_deepmark_ssd_cpu"
+    eval $cmd
 
     # Comment out mask_rcnn_resnet50_v1b_coco due to NGRAPH-2821
-    #cmd="pytest -s docker/scripts/test_deepmark_mask_rcnn_resnet50_gluoncv_inference.py --junit-xml=validation_test_deepmark_mask_rcnn_resnet50_gluonvc_inference.xml --junit-prefix=inference_deepmark_mask_rcnn_resnet50_gluoncv_cpu"
-    #eval $cmd
+    cmd="pytest -s docker/scripts/test_deepmark_mask_rcnn_resnet50_gluoncv_inference.py --junit-xml=validation_test_deepmark_mask_rcnn_resnet50_gluonvc_inference.xml --junit-prefix=inference_deepmark_mask_rcnn_resnet50_gluoncv_cpu"
+    eval $cmd
 
     echo "===== Inference CPU-Backend Pipeline Exited with $? ====="
 

--- a/docker/scripts/run-ng-mx-deepmark-tests.sh
+++ b/docker/scripts/run-ng-mx-deepmark-tests.sh
@@ -52,8 +52,6 @@ run_inference_topologies() {
     export TEST_KMP_AFFINITY="${MX_NG_KMP_AFFINITY}"
     export TEST_DEEPMARK_TYPE="${MX_NG_DEEPMARK_TYPE}"
 
-    echo "LD_LIBRARY_PATH ======"
-    echo ${LD_LIBRARY_PATH}
     export LD_LIBRARY_PATH="${HOME}/ng-mx/warp-ctc/build"${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
     echo "LD_LIBRARY_PATH 2 :======"
     echo ${LD_LIBRARY_PATH}

--- a/docker/scripts/run-ng-mx-deepmark-tests.sh
+++ b/docker/scripts/run-ng-mx-deepmark-tests.sh
@@ -60,61 +60,65 @@ run_inference_topologies() {
         echo "Faster-RCNN doesn't work with any --batch-size except 1."
     fi
 
-    # Run the inception_v4
-    cmd="pytest -s docker/scripts/test_deepmark_inception_v4_inference.py --junit-xml=validation_test_deepmark_inception_v4_inference.xml --junit-prefix=inference_deepmark_inception_v4_cpu"
+    # Run DeepSpeec 2
+    cmd="pytest -s docker/scripts/test_deepmark_deepspeed_inference.py --junit-xml=validation_test_deepmark_deepspeed_inference.xml --junit-prefix=inference_deepmark_deepspeed"
     eval $cmd
+
+    # Run the inception_v4
+    #cmd="pytest -s docker/scripts/test_deepmark_inception_v4_inference.py --junit-xml=validation_test_deepmark_inception_v4_inference.xml --junit-prefix=inference_deepmark_inception_v4_cpu"
+    #eval $cmd
 
     # Run the inception_v3
-    cmd="pytest -s docker/scripts/test_deepmark_inception_v3_inference.py --junit-xml=validation_test_deepmark_inception_v3_inference.xml --junit-prefix=inference_deepmark_inception_v3_cpu"
-    eval $cmd
+    #cmd="pytest -s docker/scripts/test_deepmark_inception_v3_inference.py --junit-xml=validation_test_deepmark_inception_v3_inference.xml --junit-prefix=inference_deepmark_inception_v3_cpu"
+    #eval $cmd
 
     # Run the inception_resnet_v2
-    cmd="pytest -s docker/scripts/test_deepmark_inception_resnet_v2_inference.py --junit-xml=validation_test_deepmark_inception_resnet_v2_inference.xml --junit-prefix=inference_deepmark_inception_resnet_v2_cpu"
-    eval $cmd
+    #cmd="pytest -s docker/scripts/test_deepmark_inception_resnet_v2_inference.py --junit-xml=validation_test_deepmark_inception_resnet_v2_inference.xml --junit-prefix=inference_deepmark_inception_resnet_v2_cpu"
+    #eval $cmd
 
     # Run the resnet_50
-    cmd="pytest -s docker/scripts/test_deepmark_resnet_50_inference.py --junit-xml=validation_test_deepmark_resnet_50_inference.xml --junit-prefix=inference_deepmark_resnet_50_cpu"
-    eval $cmd
+    #cmd="pytest -s docker/scripts/test_deepmark_resnet_50_inference.py --junit-xml=validation_test_deepmark_resnet_50_inference.xml --junit-prefix=inference_deepmark_resnet_50_cpu"
+    #eval $cmd
 
     # Run the a3c
-    cmd="pytest -s docker/scripts/test_deepmark_a3c_inference.py --junit-xml=validation_test_deepmark_a3c_inference.xml --junit-prefix=inference_deepmark_a3c_cpu"
-    eval $cmd
+    #cmd="pytest -s docker/scripts/test_deepmark_a3c_inference.py --junit-xml=validation_test_deepmark_a3c_inference.xml --junit-prefix=inference_deepmark_a3c_cpu"
+    #eval $cmd
 
     # Run the test wide_deep
-    cmd="pytest -s docker/scripts/test_deepmark_wide_deep_inference.py --junit-xml=validation_test_deepmark_wide_deep_inference.xml --junit-prefix=inference_deepmark_wide_deep_cpu"
-    eval $cmd
+    #cmd="pytest -s docker/scripts/test_deepmark_wide_deep_inference.py --junit-xml=validation_test_deepmark_wide_deep_inference.xml --junit-prefix=inference_deepmark_wide_deep_cpu"
+    #eval $cmd
 
     # Run the test mobilenet
-    cmd="pytest -s docker/scripts/test_deepmark_mobilenet_inference.py --junit-xml=validation_test_deepmark_mobilenet_inference.xml --junit-prefix=inference_deepmark_mobilenet_cpu"
-    eval $cmd
+    #cmd="pytest -s docker/scripts/test_deepmark_mobilenet_inference.py --junit-xml=validation_test_deepmark_mobilenet_inference.xml --junit-prefix=inference_deepmark_mobilenet_cpu"
+    #eval $cmd
 
     # Run the densenet121
-    cmd="pytest -s docker/scripts/test_deepmark_densenet121_inference.py --junit-xml=validation_test_deepmark_densenet121_inference.xml --junit-prefix=inference_deepmark_densenet121_cpu"
-    eval $cmd
+    #cmd="pytest -s docker/scripts/test_deepmark_densenet121_inference.py --junit-xml=validation_test_deepmark_densenet121_inference.xml --junit-prefix=inference_deepmark_densenet121_cpu"
+    #eval $cmd
 
     # Run the squeezenet1.1
-    cmd="pytest -s docker/scripts/test_deepmark_squeezenet_inference.py --junit-xml=validation_test_deepmark_squeezenet_inference.xml --junit-prefix=inference_deepmark_squeezenet_cpu"
-    eval $cmd
+    #cmd="pytest -s docker/scripts/test_deepmark_squeezenet_inference.py --junit-xml=validation_test_deepmark_squeezenet_inference.xml --junit-prefix=inference_deepmark_squeezenet_cpu"
+    #eval $cmd
 
     # Run DCGAN 
-    cmd="pytest -s docker/scripts/test_deepmark_dcgan_inference.py --junit-xml=validation_test_deepmark_dcgan_inference.xml --junit-prefix=inference_deepmark_dcgan_cpu"
-    eval $cmd
+    #cmd="pytest -s docker/scripts/test_deepmark_dcgan_inference.py --junit-xml=validation_test_deepmark_dcgan_inference.xml --junit-prefix=inference_deepmark_dcgan_cpu"
+    #eval $cmd
 
     # Run  sockeye_transformer
-    cmd="pytest -s docker/scripts/test_deepmark_sockeye_transformer_inference.py --junit-xml=validation_test_deepmark_sockeye_transformer_inference.xml --junit-prefix=inference_deepmark_sockeye_transformer_cpu"
-    eval $cmd
+    #cmd="pytest -s docker/scripts/test_deepmark_sockeye_transformer_inference.py --junit-xml=validation_test_deepmark_sockeye_transformer_inference.xml --junit-prefix=inference_deepmark_sockeye_transformer_cpu"
+    #eval $cmd
 
     # Run  sockeye_gnmt
-    cmd="pytest -s docker/scripts/test_deepmark_sockeye_gnmt_inference.py --junit-xml=validation_test_deepmark_sockeye_gnmt_inference.xml --junit-prefix=inference_deepmark_sockeye_gnmt_cpu"
-    eval $cmd
+    #cmd="pytest -s docker/scripts/test_deepmark_sockeye_gnmt_inference.py --junit-xml=validation_test_deepmark_sockeye_gnmt_inference.xml --junit-prefix=inference_deepmark_sockeye_gnmt_cpu"
+    #eval $cmd
 
     # Run ssd_512_mobilenet1_0_voc 
-    cmd="pytest -s docker/scripts/test_deepmark_ssd_512_mobilenet_inference.py --junit-xml=validation_test_deepmark_ssd_512_mobilenet_inference.xml --junit-prefix=inference_deepmark_ssd_512_mobilenet_cpu"
-    eval $cmd
+    #cmd="pytest -s docker/scripts/test_deepmark_ssd_512_mobilenet_inference.py --junit-xml=validation_test_deepmark_ssd_512_mobilenet_inference.xml --junit-prefix=inference_deepmark_ssd_512_mobilenet_cpu"
+    #eval $cmd
 
     # Run ssd
-    cmd="pytest -s docker/scripts/test_deepmark_ssd_inference.py --junit-xml=validation_test_deepmark_ssd_inference.xml --junit-prefix=inference_deepmark_ssd_cpu"
-    eval $cmd
+    #cmd="pytest -s docker/scripts/test_deepmark_ssd_inference.py --junit-xml=validation_test_deepmark_ssd_inference.xml --junit-prefix=inference_deepmark_ssd_cpu"
+    #eval $cmd
 
     # Comment out mask_rcnn_resnet50_v1b_coco due to NGRAPH-2821
     #cmd="pytest -s docker/scripts/test_deepmark_mask_rcnn_resnet50_gluoncv_inference.py --junit-xml=validation_test_deepmark_mask_rcnn_resnet50_gluonvc_inference.xml --junit-prefix=inference_deepmark_mask_rcnn_resnet50_gluoncv_cpu"

--- a/docker/scripts/run-ng-mx-deepmark-tests.sh
+++ b/docker/scripts/run-ng-mx-deepmark-tests.sh
@@ -61,10 +61,15 @@ run_inference_topologies() {
         echo "Faster-RCNN doesn't work with any --batch-size except 1."
     fi
 
-    # Run DeepSpeed 2
-    cmd="pytest -s docker/scripts/test_deepmark_deepspeed_inference.py --junit-xml=validation_test_deepmark_deepspeed_inference.xml --junit-prefix=inference_deepmark_deepspeed"
-    eval $cmd
-
+    ## Issue NGRAPH-2911
+    if [ "${TEST_BATCH_SIZE}" == "1" ] ; then
+        # Run DeepSpeed 2
+        cmd="pytest -s docker/scripts/test_deepmark_deepspeed_inference.py --junit-xml=validation_test_deepmark_deepspeed_inference.xml --junit-prefix=inference_deepmark_deepspeed"
+        eval $cmd
+    else
+        echo "DeepSpeed 2 doesn't work with any --batch-size except 1."
+    fi
+    
     # Run the inception_v4
     cmd="pytest -s docker/scripts/test_deepmark_inception_v4_inference.py --junit-xml=validation_test_deepmark_inception_v4_inference.xml --junit-prefix=inference_deepmark_inception_v4_cpu"
     eval $cmd

--- a/docker/scripts/run-ng-mx-deepmark-tests.sh
+++ b/docker/scripts/run-ng-mx-deepmark-tests.sh
@@ -60,7 +60,7 @@ run_inference_topologies() {
         echo "Faster-RCNN doesn't work with any --batch-size except 1."
     fi
 
-    # Run DeepSpeec 2
+    # Run DeepSpeed 2
     cmd="pytest -s docker/scripts/test_deepmark_deepspeed_inference.py --junit-xml=validation_test_deepmark_deepspeed_inference.xml --junit-prefix=inference_deepmark_deepspeed"
     eval $cmd
 

--- a/docker/scripts/run-ng-mx-deepmark-tests.sh
+++ b/docker/scripts/run-ng-mx-deepmark-tests.sh
@@ -52,6 +52,12 @@ run_inference_topologies() {
     export TEST_KMP_AFFINITY="${MX_NG_KMP_AFFINITY}"
     export TEST_DEEPMARK_TYPE="${MX_NG_DEEPMARK_TYPE}"
 
+    echo "LD_LIBRARY_PATH ======"
+    echo ${LD_LIBRARY_PATH}
+    export LD_LIBRARY_PATH="${HOME}/ng-mx/warp-ctc/build"${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+    echo "LD_LIBRARY_PATH 2 :======"
+    echo ${LD_LIBRARY_PATH}
+
     if [ "${TEST_BATCH_SIZE}" == "1" ] ; then
         # Run the Faster-RCNN, --batch-size 1
         cmd="pytest -s docker/scripts/test_deepmark_Faster_RCNN_inference.py --junit-xml=validation_test_deepmark_Faster_RCNN_inference.xml --junit-prefix=inference_deepmark_Faster_RCNN_cpu"

--- a/docker/scripts/test_deepmark_deepspeed_inference.py
+++ b/docker/scripts/test_deepmark_deepspeed_inference.py
@@ -1,0 +1,185 @@
+# Test intended to be run using pytest
+#
+# If pytest is not installed on your server, you can install it in a virtual
+# environment:
+#
+# Set up a virtual environment
+#   Python 2: virtualenv -p python2.7 .venv && . .venv/bin/activate
+#   Python 3: python3 -m venv .venv && . .venv/bin/activate
+#   $ pip -U pytest
+#   $ pytest test_deepmark_inception_v4.py
+#   $ deactivte
+#
+# This test has no command-line parameters, as it is run via pytest.
+# This test does have environment variables that can alter how the run happens:
+#
+#     Parameter              Purpose & Default (if any)
+#
+#     TEST_OMP_NUM_THREADS       Number of OMP THREADS
+#                                default=28
+#     TEST_KMP_BLOCKTIME         Sets the time, in milliseconds, that a thread should wait
+#                                default=200
+#     TEST_DEEPMARK_LOG_DIR  directory to write log files to
+#     TEST_BATCH_SIZE            BatchSize
+#     TEST_KMP_AFFINITY          KMP_AFFINITY
+#
+# JUnit XML files can be generated using pytest's command-line options.
+# For example:
+#
+#     $ pytest -s ./test_deepmark_deepspeed.py --junit-xml=../validation_deepmark_deepspeech.xml --junit-prefix=daily_validation_deepmark_deepspeech
+
+import sys
+import os
+import re
+
+import lib_validation_testing as VT
+
+# TEST_OMP_NUM_THREADS
+if (os.environ.get('TEST_OMP_NUM_THREADS') != ''):
+    ompNumThreads= os.environ.get('TEST_OMP_NUM_THREADS')
+else:
+    ompNumThreads = 28
+
+# TEST_DEEPMARK_LOG_DIR
+if (os.environ.get('TEST_DEEPMARK_LOG_DIR') != ''):
+    sourceDir= os.environ.get('TEST_DEEPMARK_LOG_DIR')
+
+# TEST_KMP_BLOCKTIME
+if (os.environ.get('TEST_KMP_BLOCKTIME') != ''):
+    kmpBlocktime= os.environ.get('TEST_KMP_BLOCKTIME')
+else:
+    kmpBlocktime = 1
+
+# TEST_BATCH_SIZE
+if (os.environ.get('TEST_BATCH_SIZE') != ''):
+    batchsize= os.environ.get('TEST_BATCH_SIZE')
+else:
+    batchsize = 128
+
+
+# TEST_KMP_AFFINITY
+if (os.environ.get('TEST_KMP_AFFINITY') != ''):
+    kmpAff= os.environ.get('TEST_KMP_AFFINITY')
+else:
+    kmpAff = "granularity=fine,compact,1,0"
+
+if (os.environ.get('TEST_DEEPMARK_TYPE') == "Accuracy"):
+    checkAccurary = True
+elif (os.environ.get('TEST_DEEPMARK_TYPE') == "Performance"):
+    checkAccurary = False
+else:
+    print("Invalid input. Either Accuracy or Performane ... Exiting")
+    sys.exit()
+
+benchmarkScriptPath = "benchmark.py"
+# Python program to run script.  This should just be "python" (or "python2"),
+# as the virtualenv relies on PATH resolution to find the python executable
+# in the virtual environment's bin directory.
+pythonProg = 'python'
+
+
+def test_deepmark_deepspeech_cpu_backend():
+    
+    script = os.path.join(os.environ.get('TEST_DEEPMARK_LOG_DIR'), benchmarkScriptPath)
+    VT.checkScript(script)
+    # Run with NGraph CPU backend, saving timing and accuracy
+    ngraphLog = VT.runDSDeepMarkScript(sourceDir=sourceDir,
+                                logID=' nGraph',
+                                script=script,
+                                ompNumThreads=ompNumThreads,
+                                kmpAff=kmpAff,
+                                kmpBlocktime=kmpBlocktime,
+                                batchsize=batchsize,
+                                checkAccurary=checkAccurary)
+    ngraphResults = processOutput(ngraphLog)
+    
+    lDir = None
+
+    lDir = os.path.abspath(os.environ['TEST_DEEPMARK_LOG_DIR'])
+
+    if (not checkAccurary):
+        VT.writeLogToFile(ngraphLog, os.path.join(lDir, 'test_deepmark_deepspeech_cpu_ngraph.log'))
+        VT.checkScript(os.path.join(lDir, 'test_deepmark_deepspeech_cpu_ngraph.log'))
+    else:
+        VT.writeLogToFile(ngraphLog, os.path.join(lDir, 'test_deepmark_deepspeech_accuracy_cpu_ngraph.log'))
+        VT.checkScript(os.path.join(lDir, 'test_deepmark_deepspeech_accuracy_cpu_ngraph.log'))
+        assert VT.checkAccuracyResult(os.path.join(lDir, 'test_deepmark_deepspeech_accuracy_cpu_ngraph.log')) == True
+
+    #writeJenkinsDescription(ngraphLog, os.path.join(lDir, 'test_deepmark_deepspeech_jenkins_oneline.log'))
+
+
+    print("----- Deepmark Deep Speech Testing Summary ----------------------------------------")
+
+    summaryLog = None
+    if lDir != None:
+        if checkAccurary:
+            summaryLog = os.path.join(lDir, 'test_deepmark_deepspeech_accuracy_cpu_summary.log')
+        else:
+            summaryLog = os.path.join(lDir, 'test_deepmark_deepspeech_cpu_summary.log')
+
+    logOut = VT.LogAndOutput(logFile=summaryLog)
+
+    # Report commands
+    logOut.line()
+    logOut.line("Run with NGraph CPU: {}".format(ngraphResults['command']))
+
+    # Report parameters
+    logOut.line()
+    logOut.line("Batch size:       {} (fixed)".format(batchsize))
+    logOut.line("OMP_NUM_THREADS:       {} (fixed)".format(ompNumThreads))
+    logOut.line("KMP_AFFINITY:       {} (fixed)".format(kmpAff))
+
+# End: test_deepmark_deepspeech_cpu_backend()
+
+
+# Returns array of captured stdout/stderr lines, for post-processing
+
+
+# Returns dictionary with results extracted from the run:
+#     'command':    Command that was run
+
+def processOutput(log):
+
+    command = None
+    network = None
+    one_line = None
+
+    # Dummy processing for proof-of-concept
+    lineCount = 0
+    for line in log:
+        if re.match("Command is:", line):
+            if command == None:
+                lArray = line.split('"')
+                command = str(lArray[1].strip('"'))
+                print("Found command = [{}]".format(command))
+            else:
+                raise Exception("Multiple command-is lines found")
+
+        if re.match("network:", line):
+            if one_line == None:
+                one_line = line
+                print("Found one_line = {}".format(one_line))
+            else:
+                raise Exception("Multiple network lines found")
+        
+        lineCount += 1
+    return {'command': command,
+            'one_line': one_line}
+# End: processOutput
+
+def writeJenkinsDescription(ngResults, fileName):
+
+    print("Jenkins description written to {}".format(fileName))
+
+    try: 
+
+        fOut = open( fileName, 'w')
+
+        fOut.write("DeepSpeech type: {}\n\t{}".format(ngResults['command'],ngResults['one_line']))
+
+        fOut.close()
+
+    except Exception as e:
+        print("Unable to write Jenkins description file - {}".format(e))
+
+# End: writeJenkinsDescription()


### PR DESCRIPTION
## Description ##
PR to test inference of the DeepSpeech 2.
There are some modifies in this PR:
1. Clone https://github.com/baidu-research/warp-ctc.git inside the docker container (https://github.intel.com/AIPG/cje-algo/pull/259)
2. Modify the config.mk, and build Ngraph_Mxnet with warp-ctc.
2. Run the DeepSpeech2. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
