### PR TITLE
NGRAPH-3073: daily validation for ngraph-mxnet to test with latest version of nGraph master branch

### DIFF
--- a/docker/Dockerfiles/docker-mx-ng-install.sh
+++ b/docker/Dockerfiles/docker-mx-ng-install.sh
@@ -38,6 +38,9 @@ echo " PYTHON_VERSION_NUMBER = ${PYTHON_VERSION_NUMBER}"
 echo "======MAKE_VARIABLES========"
 echo " MAKE_VARIABLES= ${MAKE_VARIABLES}"
 
+echo "======NGRAPH_BRANCH========"
+echo " NGRAPH_BRANCH= ${NGRAPH_BRANCH}"
+
 # Note that the docker image must have been previously built using the
 # make-docker-mx-ngraph-base.sh script (in the same directory as this script).
 
@@ -61,6 +64,7 @@ docker run --rm \
       --env RUN_CMD="${docker_mx_dir}/docker/scripts/${script}" \
       --env PYTHON_VERSION_NUMBER="${PYTHON_VERSION_NUMBER}"\
       --env MAKE_VARIABLES="${MAKE_VARIABLES}" \
+      --env NGRAPH_BRANCH="${NGRAPH_BRANCH}" \
       --env http_proxy=http://proxy-fm.intel.com:911 \
       --env https_proxy=http://proxy-fm.intel.com:912 \
       -v "${ngraph_mx_dir}:${docker_mx_dir}" \

--- a/docker/scripts/build-install-mx.sh
+++ b/docker/scripts/build-install-mx.sh
@@ -30,7 +30,8 @@ echo "**************************************************************************
 cd "${MX_DIR}"
 git submodule update --init --recursive
 
-if [ -z "${NGRAPH_BRANCH}" ] ; then
+if [ ! -z "${NGRAPH_BRANCH}" ] ; then
+	echo "NGRAPH_BRANCH == ${NGRAPH_BRANCH}"
     cd "${MX_DIR}/3rdparty/ngraph-mxnet-bridge/cmake"
     sed -e "/GIT_TAG/s/.*/        GIT_TAG ${NGRAPH_BRANCH}/" ngraph.cmake > ngraph.cmake.test
     cp ngraph.cmake.test ngraph.cmake

--- a/docker/scripts/build-install-mx.sh
+++ b/docker/scripts/build-install-mx.sh
@@ -32,9 +32,10 @@ git submodule update --init --recursive
 
 if [[ "${NGRAPH_BRANCH}" == "master" ]] ; then
     cd "${MX_DIR}/3rdparty/ngraph-mxnet-bridge"
-    git fetch
-    git checkout origin/master
-    echo "git log -1"
+    echo `pwd`
+    echo `git fetch`
+    echo `git checkout origin/master`
+    echo `git log -1`
 fi
 
 echo "The make variable is: ${MAKE_VARIABLES}"

--- a/docker/scripts/build-install-mx.sh
+++ b/docker/scripts/build-install-mx.sh
@@ -30,15 +30,12 @@ echo "**************************************************************************
 cd "${MX_DIR}"
 git submodule update --init --recursive
 
-if [[ "${NGRAPH_BRANCH}" == "master" ]] ; then
-    cd "${MX_DIR}/3rdparty/ngraph-mxnet-bridge"
-    echo `pwd`
-    echo `git fetch`
-    echo `git checkout ci_ngraph_master`
-    echo `git log -1`
+if [ -z "${NGRAPH_BRANCH}" ] ; then
+    cd "${MX_DIR}/3rdparty/ngraph-mxnet-bridge/cmake"
+    sed -e "/GIT_TAG/s/.*/        GIT_TAG ${NGRAPH_BRANCH}/" ngraph.cmake > ngraph.cmake.test
+    cp ngraph.cmake.test ngraph.cmake
+    rm -rf ngraph.cmake.test
 fi
-
-echo "The make variable is: ${MAKE_VARIABLES}"
 
 case "${MAKE_VARIABLES}" in
 	USE_NGRAPH)

--- a/docker/scripts/build-install-mx.sh
+++ b/docker/scripts/build-install-mx.sh
@@ -34,7 +34,7 @@ if [[ "${NGRAPH_BRANCH}" == "master" ]] ; then
     cd "${MX_DIR}/3rdparty/ngraph-mxnet-bridge"
     echo `pwd`
     echo `git fetch`
-    echo `git checkout origin/master`
+    echo `git checkout origin/ci_ngraph_master`
     echo `git log -1`
 fi
 

--- a/docker/scripts/build-install-mx.sh
+++ b/docker/scripts/build-install-mx.sh
@@ -32,14 +32,12 @@ git submodule update --init --recursive
 
 if [ ! -z "${NGRAPH_BRANCH}" ] ; then
 	echo "NGRAPH_BRANCH == ${NGRAPH_BRANCH}"
-	echo "Here is : `pwd` "
-	echo "ls : `ls` "
     cd "3rdparty/ngraph-mxnet-bridge/cmake"
     sed -e "/GIT_TAG/s/.*/        GIT_TAG ${NGRAPH_BRANCH}/" ngraph.cmake > ngraph.cmake.test
     cp ngraph.cmake.test ngraph.cmake
     rm -rf ngraph.cmake.test
 fi
-
+cd "${MX_DIR}"
 case "${MAKE_VARIABLES}" in
 	USE_NGRAPH)
 		echo "Building MXnet with experimental nGraph integration enabled. Engine: CPU + MKLDNN"

--- a/docker/scripts/build-install-mx.sh
+++ b/docker/scripts/build-install-mx.sh
@@ -32,7 +32,9 @@ git submodule update --init --recursive
 
 if [ ! -z "${NGRAPH_BRANCH}" ] ; then
 	echo "NGRAPH_BRANCH == ${NGRAPH_BRANCH}"
-    cd "${MX_DIR}/3rdparty/ngraph-mxnet-bridge/cmake"
+	echo "Here is : `pwd` "
+	echo "ls : `ls` "
+    cd "3rdparty/ngraph-mxnet-bridge/cmake"
     sed -e "/GIT_TAG/s/.*/        GIT_TAG ${NGRAPH_BRANCH}/" ngraph.cmake > ngraph.cmake.test
     cp ngraph.cmake.test ngraph.cmake
     rm -rf ngraph.cmake.test

--- a/docker/scripts/build-install-mx.sh
+++ b/docker/scripts/build-install-mx.sh
@@ -34,7 +34,7 @@ if [[ "${NGRAPH_BRANCH}" == "master" ]] ; then
     cd "${MX_DIR}/3rdparty/ngraph-mxnet-bridge"
     echo `pwd`
     echo `git fetch`
-    echo `git checkout origin/ci_ngraph_master`
+    echo `git checkout ci_ngraph_master`
     echo `git log -1`
 fi
 

--- a/docker/scripts/build-install-mx.sh
+++ b/docker/scripts/build-install-mx.sh
@@ -29,6 +29,14 @@ echo "**************************************************************************
 
 cd "${MX_DIR}"
 git submodule update --init --recursive
+
+if [[ "${NGRAPH_BRANCH}" == "master" ]] ; then
+    cd "${MX_DIR}/3rdparty/ngraph-mxnet-bridge"
+    git fetch
+    git checkout origin/master
+    echo "git log -1"
+fi
+
 echo "The make variable is: ${MAKE_VARIABLES}"
 
 case "${MAKE_VARIABLES}" in

--- a/docker/scripts/run-ng-mx-install.sh
+++ b/docker/scripts/run-ng-mx-install.sh
@@ -57,6 +57,7 @@ echo  ' '
 export PIP_INSTALL_FROM_SUDO=1
 export PIP_INSTALL_EXTRA_ARGS="--proxy=$http_proxy --proxy=$https_proxy"
 export MAKE_VARIABLES="${MAKE_VARIABLES}"
+export NGRAPH_BRANCH="${NGRAPH_BRANCH}"
 ./build-install-mx.sh 2>&1 | tee ../mx-build.log
 echo "===== Build & Install Pipeline Exited with $? and endtime ${xtime} ===="
 


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
