### PR TITLE
handle cases where PartitionGraph is not ran before Init().

### DIFF
--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -328,7 +328,8 @@ void GraphExecutor::Init(nnvm::Symbol symbol,
   nnvm::DTypeVector arg_dtypes;
   StorageTypeVector arg_stypes(idx.num_node_entries(), -1);
   for (size_t i = 0; i < num_forward_inputs_; ++i) {
-    const uint32_t nid = input_nodes.empty() ? idx.input_nodes().at(i) : idx.node_id(input_nodes[i]);
+    const uint32_t nid = input_nodes.empty() ? idx.input_nodes().at(i) :
+                                               idx.node_id(input_nodes[i]);
     const std::string& arg_name = idx[nid].source->attrs.name;
     size_t eid = idx.entry_id(nid, 0);
     if (mutable_nodes.count(nid)) {
@@ -417,7 +418,8 @@ void GraphExecutor::InitArguments(const nnvm::IndexedGraph& idx,
   size_t arg_top = 0, aux_top = 0;
   const auto& mutable_nodes = idx.mutable_input_nodes();
   for (size_t i = 0; i < num_forward_inputs_; ++i) {
-    const uint32_t nid = input_nodes.empty() ? idx.input_nodes().at(i) : idx.node_id(input_nodes[i]);
+    const uint32_t nid = input_nodes.empty() ? idx.input_nodes().at(i) :
+                                               idx.node_id(input_nodes[i]);
     const uint32_t eid = idx.entry_id(nid, 0);
     const TShape& inferred_shape = inferred_shapes[eid];
     const int inferred_dtype = inferred_dtypes[eid];
@@ -490,7 +492,8 @@ void GraphExecutor::InitArguments(const nnvm::IndexedGraph& idx,
   size_t arg_top = 0, aux_top = 0;
   const auto& mutable_nodes = idx.mutable_input_nodes();
   for (size_t i = 0; i < num_forward_inputs_; ++i) {
-    const uint32_t nid = input_nodes.empty() ? idx.input_nodes().at(i) : idx.node_id(input_nodes[i]);
+    const uint32_t nid = input_nodes.empty() ? idx.input_nodes().at(i) :
+                                               idx.node_id(input_nodes[i]);
     const uint32_t eid = idx.entry_id(nid, 0);
     const TShape& inferred_shape = inferred_shapes[eid];
     const int inferred_dtype = inferred_dtypes[eid];
@@ -1613,10 +1616,10 @@ Executor *Executor::SimpleBind(nnvm::Symbol symbol,
                                std::unordered_map<std::string, NDArray>* shared_buffer,
                                Executor* shared_exec) {
   auto exec = new exec::GraphExecutor();
-  // PartitionGraph() may modify the original graph and change the input node 
+  // PartitionGraph() may modify the original graph and change the input node
   // ordering due to IndexedGraph DFS traveral. It will store the nnvm node* in
-  // the original order in input_nodes to match the expected order from python 
-  // side during Init(). If input_nodes is empty, it means ParitionGraph() has 
+  // the original order in input_nodes to match the expected order from python
+  // side during Init(). If input_nodes is empty, it means ParitionGraph() has
   // not been called, and input nodes order has not been modified.
   std::vector<const nnvm::Node*> input_nodes;
   if (!exec->subgraph_property().empty() && group2ctx.empty()) {
@@ -1642,10 +1645,10 @@ Executor *Executor::Bind(nnvm::Symbol symbol,
                          const std::vector<NDArray> &aux_states,
                          Executor* shared_exec) {
   auto exec = new exec::GraphExecutor();
-  // PartitionGraph() may modify the original graph and change the input node 
+  // PartitionGraph() may modify the original graph and change the input node
   // ordering due to IndexedGraph DFS traveral. It will store the nnvm node* in
-  // the original order in input_nodes to match the expected order from python 
-  // side during Init(). If input_nodes is empty, it means ParitionGraph() has 
+  // the original order in input_nodes to match the expected order from python
+  // side during Init(). If input_nodes is empty, it means ParitionGraph() has
   // not been called, and input nodes order has not been modified.
   std::vector<const nnvm::Node*> input_nodes;
   if (!exec->subgraph_property().empty() && group2ctx.empty()) {

--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -328,7 +328,7 @@ void GraphExecutor::Init(nnvm::Symbol symbol,
   nnvm::DTypeVector arg_dtypes;
   StorageTypeVector arg_stypes(idx.num_node_entries(), -1);
   for (size_t i = 0; i < num_forward_inputs_; ++i) {
-    const uint32_t nid = idx.node_id(input_nodes[i]);
+    const uint32_t nid = input_nodes.empty() ? idx.input_nodes().at(i) : idx.node_id(input_nodes[i]);
     const std::string& arg_name = idx[nid].source->attrs.name;
     size_t eid = idx.entry_id(nid, 0);
     if (mutable_nodes.count(nid)) {
@@ -417,7 +417,7 @@ void GraphExecutor::InitArguments(const nnvm::IndexedGraph& idx,
   size_t arg_top = 0, aux_top = 0;
   const auto& mutable_nodes = idx.mutable_input_nodes();
   for (size_t i = 0; i < num_forward_inputs_; ++i) {
-    const uint32_t nid = idx.node_id(input_nodes[i]);
+    const uint32_t nid = input_nodes.empty() ? idx.input_nodes().at(i) : idx.node_id(input_nodes[i]);
     const uint32_t eid = idx.entry_id(nid, 0);
     const TShape& inferred_shape = inferred_shapes[eid];
     const int inferred_dtype = inferred_dtypes[eid];
@@ -490,7 +490,7 @@ void GraphExecutor::InitArguments(const nnvm::IndexedGraph& idx,
   size_t arg_top = 0, aux_top = 0;
   const auto& mutable_nodes = idx.mutable_input_nodes();
   for (size_t i = 0; i < num_forward_inputs_; ++i) {
-    const uint32_t nid = idx.node_id(input_nodes[i]);
+    const uint32_t nid = input_nodes.empty() ? idx.input_nodes().at(i) : idx.node_id(input_nodes[i]);
     const uint32_t eid = idx.entry_id(nid, 0);
     const TShape& inferred_shape = inferred_shapes[eid];
     const int inferred_dtype = inferred_dtypes[eid];
@@ -1613,6 +1613,11 @@ Executor *Executor::SimpleBind(nnvm::Symbol symbol,
                                std::unordered_map<std::string, NDArray>* shared_buffer,
                                Executor* shared_exec) {
   auto exec = new exec::GraphExecutor();
+  // PartitionGraph() may modify the original graph and change the input node 
+  // ordering due to IndexedGraph DFS traveral. It will store the nnvm node* in
+  // the original order in input_nodes to match the expected order from python 
+  // side during Init(). If input_nodes is empty, it means ParitionGraph() has 
+  // not been called, and input nodes order has not been modified.
   std::vector<const nnvm::Node*> input_nodes;
   if (!exec->subgraph_property().empty() && group2ctx.empty()) {
     symbol = exec::PartitionGraph(symbol, exec->subgraph_property(), arg_shape_map, arg_dtype_map,
@@ -1637,6 +1642,11 @@ Executor *Executor::Bind(nnvm::Symbol symbol,
                          const std::vector<NDArray> &aux_states,
                          Executor* shared_exec) {
   auto exec = new exec::GraphExecutor();
+  // PartitionGraph() may modify the original graph and change the input node 
+  // ordering due to IndexedGraph DFS traveral. It will store the nnvm node* in
+  // the original order in input_nodes to match the expected order from python 
+  // side during Init(). If input_nodes is empty, it means ParitionGraph() has 
+  // not been called, and input nodes order has not been modified.
   std::vector<const nnvm::Node*> input_nodes;
   if (!exec->subgraph_property().empty() && group2ctx.empty()) {
     symbol = exec::PartitionGraph(symbol, exec->subgraph_property(), in_args, aux_states,


### PR DESCRIPTION
## Description ##
Fixed a bug when `ParitionGraph()` is not ran, `input_nodes` is empty and causes a segfault.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
