### PR TITLE
Add NGRAPH_BRANCH into daily validation

### DIFF
--- a/docker/Dockerfiles/docker-mx-ng-validation.sh
+++ b/docker/Dockerfiles/docker-mx-ng-validation.sh
@@ -65,6 +65,7 @@ docker run --rm \
        --env RUN_CMD="${docker_mx_dir}/docker/scripts/${script}" \
        --env PYTHON_VERSION_NUMBER="${PYTHON_VERSION_NUMBER}" \
        --env MAKE_VARIABLES="${MAKE_VARIABLES}" \
+       --env NGRAPH_BRANCH="${NGRAPH_BRANCH} \
        --env MX_NG_MODEL="${MX_NG_MODEL}" \
        --env MX_NG_EPOCHS="${MX_NG_EPOCHS}" \
        --env MX_NG_DO_NOT_RUN="${MX_NG_DO_NOT_RUN}" \

--- a/docker/Dockerfiles/docker-mx-ng-validation.sh
+++ b/docker/Dockerfiles/docker-mx-ng-validation.sh
@@ -69,7 +69,7 @@ docker run --rm \
        --env RUN_CMD="${docker_mx_dir}/docker/scripts/${script}" \
        --env PYTHON_VERSION_NUMBER="${PYTHON_VERSION_NUMBER}" \
        --env MAKE_VARIABLES="${MAKE_VARIABLES}" \
-       --env NGRAPH_BRANCH="${NGRAPH_BRANCH} \
+       --env NGRAPH_BRANCH="${NGRAPH_BRANCH}" \
        --env MX_NG_MODEL="${MX_NG_MODEL}" \
        --env MX_NG_EPOCHS="${MX_NG_EPOCHS}" \
        --env MX_NG_DO_NOT_RUN="${MX_NG_DO_NOT_RUN}" \

--- a/docker/Dockerfiles/docker-mx-ng-validation.sh
+++ b/docker/Dockerfiles/docker-mx-ng-validation.sh
@@ -33,6 +33,10 @@ else
     export PYTHON_VERSION_NUMBER="${2}"
 fi
 
+
+echo "======NGRAPH_BRANCH========"
+echo " NGRAPH_BRANCH= ${NGRAPH_BRANCH}"
+
 # Note that the docker image must have been previously built using the
 # make-docker-mx-ngraph-base.sh script (in the same directory as this script).
 

--- a/docker/scripts/build-install-mx.sh
+++ b/docker/scripts/build-install-mx.sh
@@ -30,7 +30,7 @@ echo "**************************************************************************
 cd "${MX_DIR}"
 git submodule update --init --recursive
 
-if [ ! -z "${NGRAPH_BRANCH}" ] && [ "${NGRAPH_BRANCH}" != "defautl" ] ; then
+if [ ! -z "${NGRAPH_BRANCH}" ] && [ "${NGRAPH_BRANCH}" != "default" ] ; then
     echo "NGRAPH_BRANCH == ${NGRAPH_BRANCH}"
     cd "3rdparty/ngraph-mxnet-bridge/cmake"
     sed -e "/GIT_TAG/s/.*/        GIT_TAG ${NGRAPH_BRANCH}/" ngraph.cmake > ngraph.cmake.test

--- a/docker/scripts/build-install-mx.sh
+++ b/docker/scripts/build-install-mx.sh
@@ -30,12 +30,14 @@ echo "**************************************************************************
 cd "${MX_DIR}"
 git submodule update --init --recursive
 
-if [ ! -z "${NGRAPH_BRANCH}" ] ; then
-	echo "NGRAPH_BRANCH == ${NGRAPH_BRANCH}"
+if [ ! -z "${NGRAPH_BRANCH}" ] && [ "${NGRAPH_BRANCH}" != "defautl" ] ; then
+    echo "NGRAPH_BRANCH == ${NGRAPH_BRANCH}"
     cd "3rdparty/ngraph-mxnet-bridge/cmake"
     sed -e "/GIT_TAG/s/.*/        GIT_TAG ${NGRAPH_BRANCH}/" ngraph.cmake > ngraph.cmake.test
     cp ngraph.cmake.test ngraph.cmake
     rm -rf ngraph.cmake.test
+else
+    echo "ngraphBranch === ${NGRAPH_BRANCH}"
 fi
 cd "${MX_DIR}"
 case "${MAKE_VARIABLES}" in

--- a/docker/scripts/run-mx-ngraph-validation-test.sh
+++ b/docker/scripts/run-mx-ngraph-validation-test.sh
@@ -176,6 +176,7 @@ echo  ' '
 export PIP_INSTALL_FROM_SUDO=1
 export PIP_INSTALL_EXTRA_ARGS="--proxy=$http_proxy --proxy=$https_proxy"
 export MAKE_VARIABLES="${MAKE_VARIABLES}"
+export NGRAPH_BRANCH="${NGRAPH_BRANCH}"
 ./build-install-mx.sh 2>&1 | tee ../mx-build.log
 echo "===== Build & Install Pipeline Exited with $? and endtime ${xtime} ===="
 


### PR DESCRIPTION
## Description ##
- Add NGRAPH_BRANCH into daily validation . It means we can set any NGRAPH_BRANCH to execute any daily validation ( Full unit tests or training models). 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here