### PR TITLE
Lam/ci gpu cuda8

### DIFF
--- a/docker/Dockerfiles/Dockerfile.ci.gpu.cuda8.mxnet
+++ b/docker/Dockerfiles/Dockerfile.ci.gpu.cuda8.mxnet
@@ -15,12 +15,14 @@
 # ********************************************************************************
 
 # Environment to build and run unit tests for ngraph-mxnet on gpu
-# with gcc 5.4 by defaul
-# with clang 3.9
+# with cuda 8
+# with libcudnn7-dev_7.0.1.13
 # with capabilities for python 2.7 and python 3
 # Author: Lam Nguyen
 
-FROM nvidia/cuda:9.1-cudnn7-devel
+FROM nvidia/cuda:8.0-devel-ubuntu16.04
+
+RUN echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1604/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list
 
 # try to get around issue with badsig
 RUN rm /etc/apt/sources.list.d/cuda.list
@@ -28,6 +30,10 @@ RUN rm /etc/apt/sources.list.d/cuda.list
 # removing nvidia-ml.list file to avoid apt-get update error
 # "The method driver /usr/lib/apt/methods/https could not be found."
 RUN rm /etc/apt/sources.list.d/nvidia-ml.list
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+            libcudnn7-dev_7.0.1.13-1+cuda8.0_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && \
     apt-get install -y curl apt-transport-https ca-certificates && \
@@ -74,4 +80,3 @@ RUN pip install pytest-xdist
 WORKDIR /home
 ADD scripts/run-as-user.sh /home/run-as-user.sh
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
-

--- a/docker/Dockerfiles/Dockerfile.ci.gpu.cuda8.mxnet
+++ b/docker/Dockerfiles/Dockerfile.ci.gpu.cuda8.mxnet
@@ -20,7 +20,12 @@
 # with capabilities for python 2.7 and python 3
 # Author: Lam Nguyen
 
-FROM nvidia/cuda:8.0-devel-ubuntu16.04
+#FROM nvidia/cuda:8.0-devel-ubuntu16.04
+FROM nvidia/cuda:8.0-cudnn5-devel
+
+COPY install/cpp.sh install/
+RUN install/cpp.sh
+
 
 RUN echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1604/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list
 
@@ -31,9 +36,9 @@ RUN rm /etc/apt/sources.list.d/cuda.list
 # "The method driver /usr/lib/apt/methods/https could not be found."
 RUN rm /etc/apt/sources.list.d/nvidia-ml.list
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-            libcudnn7-dev_7.0.1.13-1+cuda8.0_amd64.deb && \
-    rm -rf /var/lib/apt/lists/*
+#RUN apt-get update && apt-get install -y --no-install-recommends \
+#            libcudnn7-dev_7.0.1.13-1+cuda8.0_amd64.deb && \
+#    rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && \
     apt-get install -y curl apt-transport-https ca-certificates && \

--- a/docker/Dockerfiles/Dockerfile.ci.gpu.cuda8.mxnet
+++ b/docker/Dockerfiles/Dockerfile.ci.gpu.cuda8.mxnet
@@ -21,7 +21,7 @@
 # Author: Lam Nguyen
 
 #FROM nvidia/cuda:8.0-devel-ubuntu16.04
-FROM nvidia/cuda:8.0-cudnn5-devel
+FROM nvidia/cuda:8.0-cudnn7-devel
 
 COPY install/cpp.sh install/
 RUN install/cpp.sh

--- a/docker/Dockerfiles/Dockerfile.ci.gpu.cuda9.mxnet
+++ b/docker/Dockerfiles/Dockerfile.ci.gpu.cuda9.mxnet
@@ -1,0 +1,75 @@
+# *******************************************************************************
+# * Copyright 2018 Intel Corporation
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# ********************************************************************************
+
+# Environment to build and run unit tests for ngraph-mxnet on gpu
+# with capabilities for python 2.7 and python 3
+# Author: Lam Nguyen
+
+FROM nvidia/cuda:9.1-cudnn7-devel
+
+# try to get around issue with badsig
+RUN rm /etc/apt/sources.list.d/cuda.list
+
+# removing nvidia-ml.list file to avoid apt-get update error
+# "The method driver /usr/lib/apt/methods/https could not be found."
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list
+
+RUN apt-get update && \
+    apt-get install -y curl apt-transport-https ca-certificates && \
+    apt-get clean autoclean && \
+    apt-get autoremove -y
+RUN curl http://developer.download.nvidia.com/compute/cuda/repos/GPGKEY | apt-key add -
+
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/cuda/include:${PATH}
+ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+
+#Install MxNet Dependencies:
+RUN apt-get update && apt-get install -y build-essential git \
+        bzip2 wget coreutils libjasper1 libjpeg8 libpng12-0 \
+        libsox-dev libgtest-dev cpio pandoc curl libtcmalloc-minimal4 \
+        libssl-dev libffi-dev \
+        libopencv-dev curl gcc libatlas-base-dev \
+        python python-pip python-dev \
+        python3 python3-pip python3-dev \
+        python-opencv graphviz python-scipy \
+        python-sklearn libopenblas-dev clang-3.9 \
+        pciutils \
+        clang-format-3.9 virtualenv cmake \
+        sudo && \
+        apt-get clean autoclean && \
+        apt-get autoremove -y
+
+RUN pip install --upgrade pip
+
+RUN pip install numpy
+
+# We include psutil
+RUN pip install psutil
+
+# We include pytest
+RUN pip install --upgrade pytest
+
+# We include pytest-xdist to speed up the testing
+RUN pip install pytest-xdist
+
+# Copy in the run-as-user.sh script
+# This will allow the builds, which are done in a mounted directory, to
+# be run as the user who runs "docker run".  This then allows the mounted
+# directory to be properly deleted by the user later (e.g. by jenkins).
+WORKDIR /home
+ADD scripts/run-as-user.sh /home/run-as-user.sh
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
+

--- a/docker/Dockerfiles/make-docker-ng-mx-gpu-base.sh
+++ b/docker/Dockerfiles/make-docker-ng-mx-gpu-base.sh
@@ -21,7 +21,11 @@
 
 set -e  # Fail on any command with non-zero exit
 
-DOCKER_FILE='Dockerfile.ci.gpu.mxnet'
+if [ "${CUDA_VERSION}" = "CUDA8" ] ; then
+  DOCKER_FILE='Dockerfile.ci.gpu.cuda8.mxnet'
+else
+  DOCKER_FILE='Dockerfile.ci.gpu.cuda9.mxnet'
+fi
 
 # The docker image name
 IMAGE_NAME='ngmx_ci_gpu'

--- a/docker/scripts/run-unit-tests-gpu.sh
+++ b/docker/scripts/run-unit-tests-gpu.sh
@@ -23,16 +23,13 @@ cd "$HOME/ng-mx"
 
 cd python && pip install -e . && pip install pytest nose scipy &&  cd ../
 
-#export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64/stubs/:/usr/local/cuda-9.2/lib64/stubs/:/usr/local/nvidia/lib64/libcuda.so.1:/usr/local/cuda-9.0/lib64/stubs/
-echo " LD_LIBRARY_PATH ==== ${LD_LIBRARY_PATH}"
-
 ## 1. Unit tests test_device.py
 cmd="OMP_NUM_THREADS=4 $(which python) -m pytest -s tests/python/gpu/test_device.py --verbose --capture=no --junit-xml=result_test_device_gpu.xml --junit-prefix=result_test_device_gpu"
 eval $cmd
 
-## 2. Unit tests test_operator_gpu.py . Disable due to NGRAPH-3118
-##cmd="OMP_NUM_THREADS=4 $(which python) -m pytest -s tests/python/gpu/test_operator_gpu.py --verbose --capture=no --junit-xml=result_test_operator_gpu.xml --junit-prefix=result_test_operator_gpu"
-##eval $cmd
+## 2. Unit tests test_operator_gpu.py will be failed with CUDA9 (NGRAPH-3118)
+cmd="OMP_NUM_THREADS=4 $(which python) -m pytest -s tests/python/gpu/test_operator_gpu.py --verbose --capture=no --junit-xml=result_test_operator_gpu.xml --junit-prefix=result_test_operator_gpu"
+eval $cmd
 
 ## 3. Unit tests test_forward.py
 cmd="OMP_NUM_THREADS=4 $(which python) -m pytest -s tests/python/gpu/test_forward.py --verbose --capture=no --junit-xml=result_test_forward_gpu.xml --junit-prefix=result_test_forward_gpu"


### PR DESCRIPTION
## Description ##
I created 2 docker files to test GPU:
1. Cuda9 + cudnn7
2. Cuda8 + cudnn7.

- Enable the test_operator_gpu.py , and filed the following issue:
1. With  Cuda9 + cudnn7, NGRAPH-3118 (jira ticket) --> Assign to Chris S
2. With Cuda8 + cudnn7, NGMX-820 (jira ticket) --> Assign to Chris S

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
