### PR TITLE
mxnet,ngraph use same MKLDNN at build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,11 @@ endif
 include $(TPARTYDIR)/mshadow/make/mshadow.mk
 include $(DMLC_CORE)/make/dmlc.mk
 
+ifeq ($(USE_MKLDNN), 1)
+  USE_MXNET_MKLDNN=1
+else
+  USE_MXNET_MKLDNN=0
+endif
 include 3rdparty/ngraph-mxnet-bridge/ngraph.mk
 
 # all tge possible warning tread

--- a/mkldnn.mk
+++ b/mkldnn.mk
@@ -26,7 +26,7 @@ ifeq ($(UNAME_S), Darwin)
 else
 	OMP_LIBFILE = $(MKLDNNROOT)/lib/libiomp5.so
 	MKLML_LIBFILE = $(MKLDNNROOT)/lib/libmklml_intel.so
-	MKLDNN_LIBFILE = $(MKLDNNROOT)/lib/libmkldnn.so.0
+	MKLDNN_LIBFILE = $(MKLDNNROOT)/lib/libmkldnn.so.0.17.1.0
 endif
 endif
 
@@ -53,6 +53,19 @@ $(MKLDNN_LIBFILE):
 mkldnn_clean:
 	$(RM) -r 3rdparty/mkldnn/build
 	$(RM) -r $(MKLDNNROOT)
+
+
+ifeq ($(USE_MKLDNN), 1)
+ifneq ($(UNAME_S), Darwin)
+
+mkldnn_symlinks:
+	mkdir -p $(MXNET_LIBDIR)
+	cd $(MXNET_LIBDIR) && \
+	ln -s --force libmkldnn.so.0.17.1.0 libmkldnn.so.0 && \
+	ln -s --force libmkldnn.so.0        libmkldnn.so
+mkldnn: mkldnn_symlinks
+endif
+endif
 
 ifeq ($(USE_MKLDNN), 1)
 mkldnn: mkldnn_build


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
