### PR TITLE
Disable deep speech due to NGMX-837 

### DIFF
--- a/docker/Dockerfiles/Dockerfile.ci.mxnet
+++ b/docker/Dockerfiles/Dockerfile.ci.mxnet
@@ -71,10 +71,10 @@ RUN gcc --version
 RUN c++ --version
 
 RUN pip install --upgrade pip
-RUN pip install numpy
+RUN pip install numpy==1.13.1
 
 # We include psutil
-RUN pip install psutil
+RUN pip install psutil==5.4.5
 
 # We include pytest
 RUN pip install --upgrade pytest

--- a/docker/scripts/run-ng-mx-deepmark-tests.sh
+++ b/docker/scripts/run-ng-mx-deepmark-tests.sh
@@ -65,13 +65,13 @@ run_inference_topologies() {
     fi
 
     ## 2. DeepSpeech 2: Issue NGRAPH-2911
-    if [ "${TEST_BATCH_SIZE}" == "1" ] ; then
+    ##if [ "${TEST_BATCH_SIZE}" == "1" ] ; then
         #24. Run DeepSpeed 2
-        cmd="pytest -s ${INFERENCE_PY_SCRIPTS}test_deepmark_deepspeech_inference.py --junit-xml=validation_test_deepmark_deepspeech_inference.xml --junit-prefix=inference_deepmark_deepspeech"
-        eval $cmd
-    else
-        echo "DeepSpeech 2 doesn't work with any --batch-size except 1."
-    fi
+    ##    cmd="pytest -s ${INFERENCE_PY_SCRIPTS}test_deepmark_deepspeech_inference.py --junit-xml=validation_test_deepmark_deepspeech_inference.xml --junit-prefix=inference_deepmark_deepspeech"
+    ##    eval $cmd
+    ##else
+    ##    echo "DeepSpeech 2 doesn't work with any --batch-size except 1."
+    ##fi
 
     ## 3. Mask_rcnn_tusimple
     if [ "${TEST_BATCH_SIZE}" == "1" ] ; then
@@ -173,8 +173,8 @@ run_inference_topologies() {
     eval $cmd
 
     # 25. Run deepspeech2_mod
-    cmd="pytest -s ${INFERENCE_PY_SCRIPTS}test_deepmark_deepspeech2_mod_inference.py --junit-xml=validation_test_deepmark_deepspeech2_mod_inference.xml --junit-prefix=inference_deepmark_deepspeech2_mod_cpu"
-    eval $cmd
+    #cmd="pytest -s ${INFERENCE_PY_SCRIPTS}test_deepmark_deepspeech2_mod_inference.py --junit-xml=validation_test_deepmark_deepspeech2_mod_inference.xml --junit-prefix=inference_deepmark_deepspeech2_mod_cpu"
+    #eval $cmd
 
     echo "===== Inference CPU-Backend Pipeline Exited with $? ====="
 

--- a/docker/scripts/run-ng-mx-deepmark-tests.sh
+++ b/docker/scripts/run-ng-mx-deepmark-tests.sh
@@ -113,8 +113,8 @@ run_inference_topologies() {
     eval $cmd
 
     # 10. Run the test wide_deep
-    cmd="pytest -s ${INFERENCE_PY_SCRIPTS}test_deepmark_wide_deep_inference.py --junit-xml=validation_test_deepmark_wide_deep_inference.xml --junit-prefix=inference_deepmark_wide_deep_cpu"
-    eval $cmd
+    #cmd="pytest -s ${INFERENCE_PY_SCRIPTS}test_deepmark_wide_deep_inference.py --junit-xml=validation_test_deepmark_wide_deep_inference.xml --junit-prefix=inference_deepmark_wide_deep_cpu"
+    #eval $cmd
 
     # 11. Run the test mobilenet
     cmd="pytest -s ${INFERENCE_PY_SCRIPTS}test_deepmark_mobilenet_inference.py --junit-xml=validation_test_deepmark_mobilenet_inference.xml --junit-prefix=inference_deepmark_mobilenet_cpu"

--- a/docker/scripts/run-ng-mx-deepmark-tests.sh
+++ b/docker/scripts/run-ng-mx-deepmark-tests.sh
@@ -113,8 +113,8 @@ run_inference_topologies() {
     eval $cmd
 
     # 10. Run the test wide_deep
-    #cmd="pytest -s ${INFERENCE_PY_SCRIPTS}test_deepmark_wide_deep_inference.py --junit-xml=validation_test_deepmark_wide_deep_inference.xml --junit-prefix=inference_deepmark_wide_deep_cpu"
-    #eval $cmd
+    cmd="pytest -s ${INFERENCE_PY_SCRIPTS}test_deepmark_wide_deep_inference.py --junit-xml=validation_test_deepmark_wide_deep_inference.xml --junit-prefix=inference_deepmark_wide_deep_cpu"
+    eval $cmd
 
     # 11. Run the test mobilenet
     cmd="pytest -s ${INFERENCE_PY_SCRIPTS}test_deepmark_mobilenet_inference.py --junit-xml=validation_test_deepmark_mobilenet_inference.xml --junit-prefix=inference_deepmark_mobilenet_cpu"

--- a/docker/scripts/run-ng-mx-deepmark-tests.sh
+++ b/docker/scripts/run-ng-mx-deepmark-tests.sh
@@ -38,7 +38,7 @@ run_inference_topologies() {
     PS2='prompt-more> '
     virtualenv -p "${PYTHON_BIN_PATH}" "${venv_dir}"
     source "${venv_dir}/bin/activate"
-    cd python && pip install -e . && pip install psutil pytest scipy gluoncv && cd ../
+    cd python && pip install -e . && pip install psutil==5.4.5 && pip install scipy==0.19.1 &&  pip install pytest &&  pip install gluoncv==0.3.0 && cd ../
     xtime="$(date)"
     echo  ' '
     echo  "===== Running Ngraph Mxnet DeepMark on CPU-Backend at ${xtime} ====="


### PR DESCRIPTION
## Description ##
1. Disable 2 tests : DeepSpeech 2 and deepspeech2_mod

2. Update the DockerFile to install the correct version numpy==1.13.1, psutil==5.4.5, scipy==0.19.1 . 
Reason:
- With the  numpy==1.15.2, psutil==5.4.8, scipy==0.20 , it causes wide-deep's accuracy FAIL. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
