### PR TITLE
Fix the security vulnerabilities.

### DIFF
--- a/docs/install/requirements.txt
+++ b/docs/install/requirements.txt
@@ -4,5 +4,5 @@ nose
 nose-timer
 numpy<=1.15.2,>=1.8.2
 pylint==1.8.3
-requests<2.19.0,>=2.18.4
+requests<3,>=2.20.0
 scipy==1.0.1

--- a/scala-package/pom.xml
+++ b/scala-package/pom.xml
@@ -37,7 +37,7 @@
   </scm>
 
   <properties>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <build.platform/>
     <cxx>g++</cxx>
     <dollar>$</dollar>


### PR DESCRIPTION
## Description ##
We have 2 security vulnerabilities issues related to version of requests and scala-compiler.

Security team requests us to update the versions of the following lib:
1. requests >=2.20.0
 2. scala-version: 2.11.12

As I mentioned to @rsketine , we pulled these 2 files directly from mxnet DO as https://github.com/apache/incubator-mxnet/blob/master/docs/install/requirements.txt, and https://github.com/apache/incubator-mxnet/blob/26b14bca0ace33b0f2767a71f7dfed52cef9c631/scala-package/pom.xml. 

However, Rama think we can fix it to PASS the security vulnerabilities. This is my temporary PR to update the:
- requests : >=2.20.0
- scala-version: 2.11.12

I will kick off tests on it. Hopefully, not much impact. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here